### PR TITLE
무게 계산기에 플레이트 시각화 기능 추가

### DIFF
--- a/actions/personalRecords.ts
+++ b/actions/personalRecords.ts
@@ -8,14 +8,16 @@ import {
 } from "@/types/personalRecords";
 import { handleDatabaseError } from "@/utils/database";
 
-export async function getUserDefaultBarbelWeight(): Promise<UserSettingRow | null> {
+export async function getUserDefaultBarbelWeight(): Promise<
+  UserSettingRow["default_barbell_weight"] | null
+> {
   const supabase = await supabaseServerClient();
 
   const { data, error } = await supabase.from("user-settings").select("*");
 
   if (error) handleDatabaseError(error);
 
-  return data?.[0] ?? null;
+  return data?.[0].default_barbell_weight ?? null;
 }
 
 export async function saveBarbellWeight(barbellWeight: number) {

--- a/actions/personalRecords.ts
+++ b/actions/personalRecords.ts
@@ -17,7 +17,7 @@ export async function getUserDefaultBarbelWeight(): Promise<
 
   if (error) handleDatabaseError(error);
 
-  return data?.[0].default_barbell_weight ?? null;
+  return data?.[0]?.default_barbell_weight ?? null;
 }
 
 export async function saveBarbellWeight(barbellWeight: number) {

--- a/app/training/weight-calculator/CalculationCards.tsx
+++ b/app/training/weight-calculator/CalculationCards.tsx
@@ -63,23 +63,18 @@ const CalculationCards = ({
                     <span
                       className={`flex items-center ${weightGap > 0 ? "text-red-500" : "text-blue-500"} gap-0.5 text-sm`}
                     >
-                      <span
-                        className={`flex items-center ${weightGap > 0 ? "text-red-500" : "text-blue-500"} gap-0.5 text-sm`}
-                      >
-                        <div className="min-h-[24px] flex items-center">
-                          {" "}
-                          {weightGap !== 0 && (
-                            <>
-                              <span>이전 무게보다 {Math.abs(weightGap)}kg</span>
-                              {weightGap > 0 ? (
-                                <ArrowUp className="w-4 h-4 ml-1" />
-                              ) : (
-                                <ArrowDown className="w-4 h-4 ml-1" />
-                              )}
-                            </>
-                          )}
-                        </div>
-                      </span>
+                      <div className="min-h-[24px] flex items-center">
+                        {weightGap !== 0 && (
+                          <>
+                            <span>이전 무게보다 {Math.abs(weightGap)}kg</span>
+                            {weightGap > 0 ? (
+                              <ArrowUp className="w-4 h-4 ml-1" />
+                            ) : (
+                              <ArrowDown className="w-4 h-4 ml-1" />
+                            )}
+                          </>
+                        )}
+                      </div>
                     </span>
 
                     <PlateVisualizer oneSidePlates={item.plates} />

--- a/app/training/weight-calculator/CalculationCards.tsx
+++ b/app/training/weight-calculator/CalculationCards.tsx
@@ -4,6 +4,7 @@ import { ArrowDown, ArrowUp, Trophy } from "lucide-react";
 import { useAtomValue } from "jotai";
 import { personalRecordAtom } from "@/entities/training/atoms/liftsAtom";
 import { LIFT_INFO_MAP } from "@/shared/constants";
+import PlateVisualizer from "@/components/PlateVisualizer";
 
 const getWeightGap = (prevWeight: number, currentWeight: number) => {
   if (prevWeight === currentWeight) {
@@ -62,23 +63,26 @@ const CalculationCards = ({
                     <span
                       className={`flex items-center ${weightGap > 0 ? "text-red-500" : "text-blue-500"} gap-0.5 text-sm`}
                     >
-                      {weightGap !== 0 && (
-                        <>
-                          {index >= 1 && (
+                      <span
+                        className={`flex items-center ${weightGap > 0 ? "text-red-500" : "text-blue-500"} gap-0.5 text-sm`}
+                      >
+                        <div className="min-h-[24px] flex items-center">
+                          {" "}
+                          {weightGap !== 0 && (
                             <>
                               <span>이전 무게보다 {Math.abs(weightGap)}kg</span>
-
-                              {/* TODO: 컬러 한 곳에서 관리하기 */}
                               {weightGap > 0 ? (
-                                <ArrowUp className="w-4 h-4 mr-1" />
+                                <ArrowUp className="w-4 h-4 ml-1" />
                               ) : (
-                                <ArrowDown className="w-4 h-4 mr-1" />
+                                <ArrowDown className="w-4 h-4 ml-1" />
                               )}
                             </>
                           )}
-                        </>
-                      )}
+                        </div>
+                      </span>
                     </span>
+
+                    <PlateVisualizer oneSidePlates={item.plates} />
                   </div>
                 </div>
               </CardContent>

--- a/app/training/weight-calculator/page.tsx
+++ b/app/training/weight-calculator/page.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useState } from "react";
 import { useAtomValue } from "jotai";
 import {
-  barbellWeightAtom,
   personalRecordAtom,
   programPercentagesAtom,
 } from "@/entities/training/atoms/liftsAtom";
@@ -11,6 +10,7 @@ import { Lift, Plates, WeightPercentage } from "@/types/training";
 import CalculationCards from "./CalculationCards";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LIFT_INFO } from "@/shared/constants";
+import { useBarbellWeight } from "@/hooks/useBarbellWeight";
 
 const AVAILABLE_PLATES: Plates = [0.5, 1, 1.5, 2, 2.5, 5, 10, 15, 20, 25];
 
@@ -57,7 +57,8 @@ const calculateProgramWeight = (
 };
 
 const WeightCalculator = () => {
-  const barWeight = useAtomValue(barbellWeightAtom);
+  const { data: barbellData } = useBarbellWeight();
+
   const personalRecord = useAtomValue(personalRecordAtom);
   const programPercentages = useAtomValue(programPercentagesAtom);
 
@@ -68,15 +69,15 @@ const WeightCalculator = () => {
       cleanAndJerk: calculateProgramWeight(
         Number(personalRecord.cleanAndJerk) ?? 0,
         programPercentages,
-        barWeight ?? 0
+        barbellData ?? 0
       ),
       snatch: calculateProgramWeight(
         Number(personalRecord.snatch) ?? 0,
         programPercentages,
-        barWeight ?? 0
+        barbellData ?? 0
       ),
     };
-  }, [barWeight, personalRecord, programPercentages]);
+  }, [barbellData, personalRecord, programPercentages]);
 
   return (
     <main className="p-4 mt-6">

--- a/app/training/weight-calculator/page.tsx
+++ b/app/training/weight-calculator/page.tsx
@@ -12,20 +12,30 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LIFT_INFO } from "@/shared/constants";
 import { useBarbellWeight } from "@/hooks/useBarbellWeight";
 
-const AVAILABLE_PLATES: Plates = [0.5, 1, 1.5, 2, 2.5, 5, 10, 15, 20, 25];
+const AVAILABLE_PLATES: Plates = [25, 20, 15, 10, 5, 2.5, 2, 1.5, 1, 0.5];
 
-function calculatePlates(totalWeight: number, barbellWeight: number): Plates {
-  let remainingWeight = totalWeight - barbellWeight;
-  if (remainingWeight <= 0) return []; // 바벨 무게보다 가벼우면 계산할 필요 없음
+/**
+ * 바벨 무게를 제외한 남은 무게를 플레이트로 계산
+ * 양쪽에 2개씩 적용 (한쪽 플레이트만 반환)
+ *
+ * @param totalWeight - 전체 무게
+ * @param barbellWeight - 바벨 무게
+ * @returns 한쪽에 필요한 플레이트 배열 (무거운 것부터)
+ */
+function calculatePlates(remainingWeight: number): Plates {
+  // 전체 무게 - 바벨 무게
 
+  if (remainingWeight <= 0) return [];
+
+  // 남은 무게 / 2 = 한쪽 무게
+  let oneSideWeight = remainingWeight / 2;
   const plates: Plates = [];
 
-  // 남은 무게를 가장 큰 플레이트부터 반복적으로 채우기
+  // 플레이트 무거운 것부터 적용
   for (const plate of AVAILABLE_PLATES) {
-    const doublePlate = plate * 2; // 양쪽에 같은 무게의 플레이트를 사용하므로 두 배로 계산
-    while (remainingWeight >= doublePlate) {
+    while (oneSideWeight >= plate) {
       plates.push(plate);
-      remainingWeight -= plate * 2;
+      oneSideWeight -= plate;
     }
   }
 
@@ -47,11 +57,12 @@ const calculateProgramWeight = (
 ) => {
   return percentages.map((program) => {
     const totalWeight = Math.ceil((pr * program.percent) / 100);
+    const remainingWeight = totalWeight - barWeight;
 
     return {
       ...program,
       totalWeight,
-      plates: calculatePlates(totalWeight, barWeight),
+      plates: calculatePlates(remainingWeight),
     };
   });
 };

--- a/components/BarbellSetting.tsx
+++ b/components/BarbellSetting.tsx
@@ -23,7 +23,7 @@ const BarbellSetting = () => {
   const { mutate: saveWeight, isPending: isSaving } = useSaveBarbellWeight();
 
   useEffect(() => {
-    if (barbellData) setSelectedWeight(barbellData.default_barbell_weight);
+    if (barbellData) setSelectedWeight(barbellData);
   }, [barbellData, setSelectedWeight]);
 
   async function handleSave() {
@@ -83,9 +83,7 @@ const BarbellSetting = () => {
           className="w-full mt-4"
           onClick={handleSave}
           disabled={
-            isSaving ||
-            !selectedWeight ||
-            selectedWeight === barbellData?.default_barbell_weight
+            isSaving || !selectedWeight || selectedWeight === barbellData
           }
         >
           {isSaving ? "저장 중..." : "저장하기"}

--- a/components/PlateVisualizer.tsx
+++ b/components/PlateVisualizer.tsx
@@ -1,0 +1,173 @@
+import { Plates } from "@/types/training";
+
+const PLATE_COLORS: Record<
+  number,
+  {
+    color: string;
+    borderColor: string;
+    label: string;
+    height: string;
+    width: string;
+  }
+> = {
+  25: {
+    color: "bg-red-600",
+    borderColor: "border-red-800",
+    label: "25kg",
+    height: "h-20",
+    width: "w-4",
+  },
+  20: {
+    color: "bg-blue-600",
+    borderColor: "border-blue-800",
+    label: "20kg",
+    height: "h-[72px]",
+    width: "w-4",
+  },
+  15: {
+    color: "bg-yellow-500",
+    borderColor: "border-yellow-700",
+    label: "15kg",
+    height: "h-16",
+    width: "w-3",
+  },
+  10: {
+    color: "bg-green-600",
+    borderColor: "border-green-800",
+    label: "10kg",
+    height: "h-14",
+    width: "w-3",
+  },
+  5: {
+    color: "bg-white",
+    borderColor: "border-gray-400",
+    label: "5kg",
+    height: "h-12",
+    width: "w-2.5",
+  },
+  2.5: {
+    color: "bg-red-400",
+    borderColor: "border-red-600",
+    label: "2.5kg",
+    height: "h-10",
+    width: "w-2",
+  },
+  2: {
+    color: "bg-blue-400",
+    borderColor: "border-blue-600",
+    label: "2kg",
+    height: "h-9",
+    width: "w-2",
+  },
+  1.5: {
+    color: "bg-yellow-400",
+    borderColor: "border-yellow-600",
+    label: "1.5kg",
+    height: "h-8",
+    width: "w-1.5",
+  },
+  1: {
+    color: "bg-green-400",
+    borderColor: "border-green-600",
+    label: "1kg",
+    height: "h-7",
+    width: "w-1.5",
+  },
+  0.5: {
+    color: "bg-gray-400",
+    borderColor: "border-gray-600",
+    label: "0.5kg",
+    height: "h-6",
+    width: "w-1",
+  },
+};
+
+interface PlateVisualizerProps {
+  oneSidePlates: Plates;
+}
+
+const PlateVisualizer = ({ oneSidePlates }: PlateVisualizerProps) => {
+  if (!oneSidePlates || oneSidePlates.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        플레이트가 필요하지 않습니다
+      </div>
+    );
+  }
+
+  // 한쪽 플레이트 총무게 계산
+  const totalOneSideWeight = oneSidePlates.reduce(
+    (sum, plate) => sum + plate,
+    0
+  );
+
+  return (
+    <div className="relative space-y-4 w-full ">
+      {/* 측면 뷰 - 바벨 + 플레이트 */}
+      <div className="flex items-center h-24">
+        {/* 바벨 바 */}
+        <div className="absolute left-0 h-3 right-0 bg-gray-700 rounded-4xl shadow-md z-0 border-2 border-gray-900" />
+
+        {/* 플레이트들 (겹쳐지도록 absolute) */}
+        <div className="absolute left-30 flex items-center">
+          {oneSidePlates.map((plate, index) => {
+            const plateConfig = PLATE_COLORS[plate];
+            if (!plateConfig) return null;
+
+            return (
+              <div
+                key={index}
+                className={`${plateConfig.color} ${plateConfig.height} ${plateConfig.width} rounded-md ${plateConfig.borderColor} group transition-transform hover:scale-105 hover:z-50 left-[${index * 6}px] border-2`}
+                title={plateConfig.label}
+              ></div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* 정면 뷰 - 플레이트 원형 */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <div className="text-sm font-semibold text-gray-700">
+          한쪽 플레이트 총무게: {totalOneSideWeight}kg
+        </div>
+        <>
+          {oneSidePlates.map((plate, index) => {
+            const plateConfig = PLATE_COLORS[plate];
+            if (!plateConfig) return null;
+
+            // 정면 뷰 크기 (원형)
+            const frontSize = {
+              25: "w-20 h-20",
+              20: "w-[72px] h-[72px]",
+              15: "w-16 h-16",
+              10: "w-14 h-14",
+              5: "w-12 h-12",
+              2.5: "w-10 h-10",
+              2: "w-9 h-9",
+              1.5: "w-8 h-8",
+              1: "w-7 h-7",
+              0.5: "w-6 h-6",
+            }[plate];
+
+            return (
+              <div
+                key={index}
+                className={`${plateConfig.color} ${frontSize} rounded-full border-2 ${plateConfig.borderColor} relative flex items-center justify-center group transition-transform hover:scale-110`}
+              >
+                {/* 중앙 구멍 */}
+                <div className="bg-white rounded-full w-1/2 h-1/2 border-2" />
+
+                {/* 무게 표시 */}
+                <span className="absolute inset-0 flex items-center justify-center text-black font-bold text-xs drop-shadow-lg pointer-events-none">
+                  {plate}
+                </span>
+              </div>
+            );
+          })}
+        </>
+      </div>
+    </div>
+  );
+};
+
+export default PlateVisualizer;

--- a/components/PlateVisualizer.tsx
+++ b/components/PlateVisualizer.tsx
@@ -1,5 +1,18 @@
 import { Plates } from "@/types/training";
 
+const PLATE_SIZE: Record<number, string> = {
+  25: "w-20 h-20",
+  20: "w-[72px] h-[72px]",
+  15: "w-16 h-16",
+  10: "w-14 h-14",
+  5: "w-12 h-12",
+  2.5: "w-10 h-10",
+  2: "w-9 h-9",
+  1.5: "w-8 h-8",
+  1: "w-7 h-7",
+  0.5: "w-6 h-6",
+};
+
 const PLATE_COLORS: Record<
   number,
   {
@@ -106,7 +119,7 @@ const PlateVisualizer = ({ oneSidePlates }: PlateVisualizerProps) => {
       {/* 측면 뷰 - 바벨 + 플레이트 */}
       <div className="flex items-center h-24">
         {/* 바벨 바 */}
-        <div className="absolute left-0 h-3 right-0 bg-gray-700 rounded-4xl shadow-md z-0 border-2 border-gray-900" />
+        <div className="absolute left-0 h-3 right-0 bg-gray-700 rounded-1xl shadow-md z-0 border-2 border-gray-900" />
 
         {/* 플레이트들 (겹쳐지도록 absolute) */}
         <div className="absolute left-30 flex items-center">
@@ -117,7 +130,7 @@ const PlateVisualizer = ({ oneSidePlates }: PlateVisualizerProps) => {
             return (
               <div
                 key={index}
-                className={`${plateConfig.color} ${plateConfig.height} ${plateConfig.width} rounded-md ${plateConfig.borderColor} group transition-transform hover:scale-105 hover:z-50 left-[${index * 6}px] border-2`}
+                className={`${plateConfig.color} ${plateConfig.height} ${plateConfig.width} rounded-md ${plateConfig.borderColor} group transition-transform hover:scale-105 hover:z-50 border-2`}
                 title={plateConfig.label}
               ></div>
             );
@@ -136,24 +149,10 @@ const PlateVisualizer = ({ oneSidePlates }: PlateVisualizerProps) => {
             const plateConfig = PLATE_COLORS[plate];
             if (!plateConfig) return null;
 
-            // 정면 뷰 크기 (원형)
-            const frontSize = {
-              25: "w-20 h-20",
-              20: "w-[72px] h-[72px]",
-              15: "w-16 h-16",
-              10: "w-14 h-14",
-              5: "w-12 h-12",
-              2.5: "w-10 h-10",
-              2: "w-9 h-9",
-              1.5: "w-8 h-8",
-              1: "w-7 h-7",
-              0.5: "w-6 h-6",
-            }[plate];
-
             return (
               <div
                 key={index}
-                className={`${plateConfig.color} ${frontSize} rounded-full border-2 ${plateConfig.borderColor} relative flex items-center justify-center group transition-transform`}
+                className={`${plateConfig.color} ${PLATE_SIZE[plate]} rounded-full border-2 ${plateConfig.borderColor} relative flex items-center justify-center group transition-transform`}
               >
                 {/* 중앙 구멍 */}
                 <div className="bg-white rounded-full w-1/2 h-1/2 border-2" />

--- a/components/PlateVisualizer.tsx
+++ b/components/PlateVisualizer.tsx
@@ -11,14 +11,14 @@ const PLATE_COLORS: Record<
   }
 > = {
   25: {
-    color: "bg-red-600",
+    color: "bg-red-900",
     borderColor: "border-red-800",
     label: "25kg",
     height: "h-20",
     width: "w-4",
   },
   20: {
-    color: "bg-blue-600",
+    color: "bg-blue-900",
     borderColor: "border-blue-800",
     label: "20kg",
     height: "h-[72px]",
@@ -46,14 +46,14 @@ const PLATE_COLORS: Record<
     width: "w-2.5",
   },
   2.5: {
-    color: "bg-red-400",
+    color: "bg-red-600",
     borderColor: "border-red-600",
     label: "2.5kg",
     height: "h-10",
     width: "w-2",
   },
   2: {
-    color: "bg-blue-400",
+    color: "bg-blue-600",
     borderColor: "border-blue-600",
     label: "2kg",
     height: "h-9",
@@ -126,11 +126,12 @@ const PlateVisualizer = ({ oneSidePlates }: PlateVisualizerProps) => {
       </div>
 
       {/* 정면 뷰 - 플레이트 원형 */}
-      <div className="flex flex-wrap gap-2 items-center">
+      <div className="flex flex-wrap gap-2 flex-col">
         <div className="text-sm font-semibold text-gray-700">
           한쪽 플레이트 총무게: {totalOneSideWeight}kg
         </div>
-        <>
+
+        <div className="flex items-center gap-2">
           {oneSidePlates.map((plate, index) => {
             const plateConfig = PLATE_COLORS[plate];
             if (!plateConfig) return null;
@@ -152,7 +153,7 @@ const PlateVisualizer = ({ oneSidePlates }: PlateVisualizerProps) => {
             return (
               <div
                 key={index}
-                className={`${plateConfig.color} ${frontSize} rounded-full border-2 ${plateConfig.borderColor} relative flex items-center justify-center group transition-transform hover:scale-110`}
+                className={`${plateConfig.color} ${frontSize} rounded-full border-2 ${plateConfig.borderColor} relative flex items-center justify-center group transition-transform`}
               >
                 {/* 중앙 구멍 */}
                 <div className="bg-white rounded-full w-1/2 h-1/2 border-2" />
@@ -164,7 +165,7 @@ const PlateVisualizer = ({ oneSidePlates }: PlateVisualizerProps) => {
               </div>
             );
           })}
-        </>
+        </div>
       </div>
     </div>
   );

--- a/entities/training/atoms/liftsAtom.ts
+++ b/entities/training/atoms/liftsAtom.ts
@@ -17,7 +17,4 @@ export const programPercentagesAtom = atomWithStorage<WeightPercentage[]>(
   []
 );
 
-// TODO: 프로그램 무게 계산 페이지 개선 후 삭제
-export const barbellWeightAtom = atom<number | null>(null);
-
 export const personalRecordsAtom = atom<PersonalRecordInfo | null>(null);


### PR DESCRIPTION
## 요약
- 바벨 무게 설정을 Jotai에서 React Query(서버 상태)로 마이그레이션
- 무게 플레이트 시각화 컴포넌트 추가 (측면 뷰 + 정면 뷰)
- 플레이트 계산 로직 개선 (한쪽 플레이트 기준으로 계산)
- 불필요한 barbellWeightAtom 제거

## 변경 사항
- 6개 파일 변경, 220줄 추가, 39줄 삭제
- 새 컴포넌트: PlateVisualizer (색상별 무게 표준 적용)
- calculatePlates() 함수 개선 (정확한 한쪽 무게 계산)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 무게판 시각화 기능이 추가되었습니다. 무게 계산 시 선택한 판의 배치를 시각적으로 확인할 수 있습니다.

* **개선사항**
  * 무게 계산 로직이 개선되어 더욱 정확한 판 조합을 제공합니다.
  * 기본 바벨 무게 설정 처리가 최적화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->