### PR TITLE
[feat] 훈련 코어 기반: DB 스키마, 타입, Query Keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.worktrees/

--- a/features/training/model/schemas.ts
+++ b/features/training/model/schemas.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+
+export const prRecordSchema = z.object({
+  liftType: z.enum(['snatch', 'clean_and_jerk'], {
+    errorMap: () => ({ message: '운동 종목을 선택하세요' }),
+  }),
+  weight: z.number({ invalid_type_error: '숫자를 입력하세요' })
+    .positive('무게는 0보다 커야 합니다')
+    .max(500, '무게는 500kg 이하여야 합니다'),
+  isGoal: z.boolean(),
+  recordedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '날짜 형식이 올바르지 않습니다'),
+})
+
+export const exerciseItemSchema = z.object({
+  exerciseType: z.string().min(1, '운동 종목을 선택하세요'),
+  reps: z.number({ invalid_type_error: '숫자를 입력하세요' })
+    .int('횟수는 정수여야 합니다')
+    .positive('횟수는 1 이상이어야 합니다')
+    .max(20, '횟수는 20 이하여야 합니다'),
+  orderIndex: z.number().int().min(0),
+})
+
+export const exerciseBlockSchema = z.object({
+  percentage: z.number({ invalid_type_error: '숫자를 입력하세요' })
+    .int('강도는 정수여야 합니다')
+    .min(1, '강도는 1% 이상이어야 합니다')
+    .max(100, '강도는 100% 이하여야 합니다'),
+  sets: z.number({ invalid_type_error: '숫자를 입력하세요' })
+    .int('세트는 정수여야 합니다')
+    .positive('세트는 1 이상이어야 합니다')
+    .max(20, '세트는 20 이하여야 합니다'),
+  orderIndex: z.number().int().min(0),
+  items: z.array(exerciseItemSchema).min(1, '운동 항목을 1개 이상 추가하세요'),
+})
+
+export const programSchema = z.object({
+  name: z.string()
+    .min(1, '프로그램 이름을 입력하세요')
+    .max(100, '프로그램 이름은 100자 이하여야 합니다'),
+  blocks: z.array(exerciseBlockSchema).min(1, '운동 블록을 1개 이상 추가하세요'),
+})
+
+export const trainingSessionSchema = z.object({
+  programId: z.string().uuid().nullable(),
+  blocks: z.array(exerciseBlockSchema.omit({ orderIndex: true })).min(1),
+  notes: z.array(z.string().max(500, '메모는 500자 이하여야 합니다')),
+  prBasis: z.enum(['current', 'goal']),
+})
+
+export type PRRecordInput = z.infer<typeof prRecordSchema>
+export type ExerciseBlockInput = z.infer<typeof exerciseBlockSchema>
+export type ProgramInput = z.infer<typeof programSchema>

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -4,4 +4,10 @@ export const QUERY_KEYS = {
   USER_SETTINGS: "userSettings",
   BARBELL_WEIGHT: "barbellWeight",
   GOALS: "goals",
-};
+  // 신규
+  PR_RECORDS: "prRecords",
+  PROGRAMS: "programs",
+  TRAINING_SESSIONS: "trainingSessions",
+  EXERCISE_TYPES: "exerciseTypes",
+  COACH_PROFILE: "coachProfile",
+} as const

--- a/supabase/migrations/20260403000000_training_core.sql
+++ b/supabase/migrations/20260403000000_training_core.sql
@@ -1,0 +1,176 @@
+-- supabase/migrations/20260403000000_training_core.sql
+
+-- 운동 종목 (시드 데이터 포함)
+create table if not exists exercise_types (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  category text not null check (category in ('snatch', 'clean_and_jerk', 'accessory')),
+  display_name text not null,
+  created_at timestamptz default now()
+);
+
+insert into exercise_types (name, category, display_name) values
+  ('power_snatch',    'snatch',          'Power Snatch'),
+  ('squat_snatch',    'snatch',          'Squat Snatch'),
+  ('snatch_pull',     'snatch',          'Snatch Pull'),
+  ('hang_snatch',     'snatch',          'Hang Snatch'),
+  ('snatch_balance',  'snatch',          'Snatch Balance'),
+  ('power_clean',     'clean_and_jerk',  'Power Clean'),
+  ('clean',           'clean_and_jerk',  'Clean'),
+  ('jerk',            'clean_and_jerk',  'Jerk'),
+  ('clean_and_jerk',  'clean_and_jerk',  'Clean & Jerk'),
+  ('clean_pull',      'clean_and_jerk',  'Clean Pull'),
+  ('hang_clean',      'clean_and_jerk',  'Hang Clean'),
+  ('deadlift',        'accessory',       'Deadlift'),
+  ('back_squat',      'accessory',       'Back Squat'),
+  ('front_squat',     'accessory',       'Front Squat'),
+  ('overhead_squat',  'accessory',       'Overhead Squat'),
+  ('push_press',      'accessory',       'Push Press'),
+  ('good_morning',    'accessory',       'Good Morning')
+on conflict (name) do nothing;
+
+-- PR 기록 (현재 PR + 목표 PR 통합, is_goal로 구분)
+create table if not exists pr_records (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  lift_type text not null check (lift_type in ('snatch', 'clean_and_jerk')),
+  weight numeric not null check (weight > 0),
+  is_goal boolean not null default false,
+  recorded_at date not null default current_date,
+  created_at timestamptz default now()
+);
+
+alter table pr_records enable row level security;
+create policy "users can manage own pr_records"
+  on pr_records for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create index pr_records_user_lift_idx on pr_records (user_id, lift_type, recorded_at desc);
+
+-- 프로그램 (유저별)
+create table if not exists programs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table programs enable row level security;
+create policy "users can manage own programs"
+  on programs for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- 프로그램 블록
+create table if not exists exercise_blocks (
+  id uuid primary key default gen_random_uuid(),
+  program_id uuid not null references programs(id) on delete cascade,
+  order_index integer not null,
+  percentage integer not null check (percentage > 0 and percentage <= 100),
+  sets integer not null check (sets > 0),
+  created_at timestamptz default now()
+);
+
+alter table exercise_blocks enable row level security;
+create policy "users can manage own exercise_blocks"
+  on exercise_blocks for all
+  using (exists (
+    select 1 from programs p
+    where p.id = exercise_blocks.program_id and p.user_id = auth.uid()
+  ));
+
+-- 블록 내 운동 항목
+create table if not exists exercise_items (
+  id uuid primary key default gen_random_uuid(),
+  block_id uuid not null references exercise_blocks(id) on delete cascade,
+  order_index integer not null,
+  exercise_type text not null,
+  reps integer not null check (reps > 0),
+  created_at timestamptz default now()
+);
+
+alter table exercise_items enable row level security;
+create policy "users can manage own exercise_items"
+  on exercise_items for all
+  using (exists (
+    select 1 from exercise_blocks eb
+    join programs p on p.id = eb.program_id
+    where eb.id = exercise_items.block_id and p.user_id = auth.uid()
+  ));
+
+-- 훈련 세션
+create table if not exists training_sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  session_date date not null default current_date,
+  program_id uuid references programs(id) on delete set null,
+  notes text[] not null default '{}',
+  pr_basis text not null check (pr_basis in ('current', 'goal')) default 'current',
+  created_at timestamptz default now()
+);
+
+alter table training_sessions enable row level security;
+create policy "users can manage own training_sessions"
+  on training_sessions for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create index training_sessions_user_date_idx on training_sessions (user_id, session_date desc);
+
+-- 세션 블록 (실제 수행 스냅샷)
+create table if not exists session_blocks (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references training_sessions(id) on delete cascade,
+  order_index integer not null,
+  percentage integer not null,
+  sets integer not null,
+  planned_weight numeric not null,
+  actual_weight numeric not null,
+  weight_status text not null check (weight_status in ('exceeded', 'as_planned', 'reduced')) default 'as_planned',
+  created_at timestamptz default now()
+);
+
+alter table session_blocks enable row level security;
+create policy "users can manage own session_blocks"
+  on session_blocks for all
+  using (exists (
+    select 1 from training_sessions ts
+    where ts.id = session_blocks.session_id and ts.user_id = auth.uid()
+  ));
+
+-- 세션 블록 항목
+create table if not exists session_block_items (
+  id uuid primary key default gen_random_uuid(),
+  session_block_id uuid not null references session_blocks(id) on delete cascade,
+  order_index integer not null,
+  exercise_type text not null,
+  reps integer not null,
+  created_at timestamptz default now()
+);
+
+alter table session_block_items enable row level security;
+create policy "users can manage own session_block_items"
+  on session_block_items for all
+  using (exists (
+    select 1 from session_blocks sb
+    join training_sessions ts on ts.id = sb.session_id
+    where sb.id = session_block_items.session_block_id and ts.user_id = auth.uid()
+  ));
+
+-- 코치 페르소나
+create table if not exists coach_profiles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  style text not null check (style in ('direct', 'technical', 'encouraging')),
+  created_at timestamptz default now(),
+  unique(user_id)
+);
+
+alter table coach_profiles enable row level security;
+create policy "users can manage own coach_profiles"
+  on coach_profiles for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/types/trainingCore.ts
+++ b/types/trainingCore.ts
@@ -1,0 +1,100 @@
+export type ExerciseCategory = 'snatch' | 'clean_and_jerk' | 'accessory'
+export type LiftType = 'snatch' | 'clean_and_jerk'
+export type WeightStatus = 'exceeded' | 'as_planned' | 'reduced'
+export type PRBasis = 'current' | 'goal'
+export type CoachStyle = 'direct' | 'technical' | 'encouraging'
+
+export interface ExerciseType {
+  id: string
+  name: string
+  category: ExerciseCategory
+  displayName: string
+}
+
+export interface ExerciseItem {
+  id: string
+  blockId: string
+  orderIndex: number
+  exerciseType: string
+  reps: number
+}
+
+export interface ExerciseBlock {
+  id: string
+  programId: string
+  orderIndex: number
+  percentage: number
+  sets: number
+  items: ExerciseItem[]
+}
+
+export interface Program {
+  id: string
+  userId: string
+  name: string
+  blocks: ExerciseBlock[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface PRRecord {
+  id: string
+  userId: string
+  liftType: LiftType
+  weight: number
+  isGoal: boolean
+  recordedAt: string
+  createdAt: string
+}
+
+export interface SessionBlockItem {
+  id: string
+  sessionBlockId: string
+  orderIndex: number
+  exerciseType: string
+  reps: number
+}
+
+export interface SessionBlock {
+  id: string
+  sessionId: string
+  orderIndex: number
+  percentage: number
+  sets: number
+  plannedWeight: number
+  actualWeight: number
+  weightStatus: WeightStatus
+  items: SessionBlockItem[]
+}
+
+export interface TrainingSession {
+  id: string
+  userId: string
+  sessionDate: string
+  programId: string | null
+  blocks: SessionBlock[]
+  notes: string[]
+  prBasis: PRBasis
+  createdAt: string
+}
+
+export interface CoachProfile {
+  id: string
+  userId: string
+  name: string
+  style: CoachStyle
+  createdAt: string
+}
+
+// 훈련 실행 중 클라이언트 상태 (저장 전)
+export interface ActiveSessionBlock {
+  tempId: string
+  orderIndex: number
+  percentage: number
+  sets: number
+  completedSets: number
+  plannedWeight: number
+  actualWeight: number
+  weightStatus: WeightStatus
+  items: Array<{ exerciseType: string; reps: number; orderIndex: number }>
+}


### PR DESCRIPTION
## 요약

- Supabase 마이그레이션 추가: `exercise_types`, `pr_records`, `programs`, `exercise_blocks`, `exercise_items`, `training_sessions`, `session_blocks`, `session_block_items`, `coach_profiles` (8개 테이블)
- 운동 종목 시드 데이터 17개 (스내치/용상/보조 종목)
- 모든 테이블 RLS 정책 적용
- TypeScript 타입 정의 (`types/trainingCore.ts`)
- Zod 검증 스키마 (`features/training/model/schemas.ts`)
- Query Keys 확장 (`lib/queryKeys.ts`)

## 다음 PR

- PR 2: PR 기능 (Server Actions + Hook + UI)
- PR 3: 프로그램 기능
- PR 4: 훈련 실행

## 테스트 계획

- [ ] `npm run type-check` 통과 확인
- [ ] Supabase 마이그레이션 파일 SQL 문법 검토
- [ ] RLS 정책이 user_id 기반으로 올바르게 설정됐는지 확인
- [ ] exercise_types 시드 데이터 17개 항목 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 트레이닝 프로그램 관리 기능 추가 (프로그램, 운동 블록, 운동 항목 구성)
  * 개인 기록(PR) 추적 기능 추가 (현재 및 목표 기록)
  * 트레이닝 세션 기록 및 조회 기능 추가 (무게 상태, 운동 노트 포함)
  * 코치 프로필 관리 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->