### PR TITLE
[feat] Phase 1C-1 - 프로그램 블록 중량 해석 모듈 (#17)

### DIFF
--- a/app/training/weight-calculator/page.tsx
+++ b/app/training/weight-calculator/page.tsx
@@ -6,41 +6,12 @@ import {
   personalRecordAtom,
   programPercentagesAtom,
 } from "@/entities/training/atoms/liftsAtom";
-import { Lift, Plates, WeightPercentage } from "@/types/training";
+import { Lift, WeightPercentage } from "@/types/training";
 import CalculationCards from "./CalculationCards";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LIFT_INFO } from "@/shared/constants";
 import { useBarbellWeight } from "@/hooks/useBarbellWeight";
-
-const AVAILABLE_PLATES: Plates = [25, 20, 15, 10, 5, 2.5, 2, 1.5, 1, 0.5];
-
-/**
- * 바벨 무게를 제외한 남은 무게를 플레이트로 계산
- * 양쪽에 2개씩 적용 (한쪽 플레이트만 반환)
- *
- * @param totalWeight - 전체 무게
- * @param barbellWeight - 바벨 무게
- * @returns 한쪽에 필요한 플레이트 배열 (무거운 것부터)
- */
-function calculatePlates(remainingWeight: number): Plates {
-  // 전체 무게 - 바벨 무게
-
-  if (remainingWeight <= 0) return [];
-
-  // 남은 무게 / 2 = 한쪽 무게
-  let oneSideWeight = remainingWeight / 2;
-  const plates: Plates = [];
-
-  // 플레이트 무거운 것부터 적용
-  for (const plate of AVAILABLE_PLATES) {
-    while (oneSideWeight >= plate) {
-      plates.push(plate);
-      oneSideWeight -= plate;
-    }
-  }
-
-  return plates;
-}
+import { calculatePlates } from "@/features/programs/model/plates";
 
 /**
  * 프로그램 퍼센트와 개인 기록(PR)을 기반으로 각 프로그램의 중량과 플레이트 조합을 계산합니다.

--- a/features/programs/model/__tests__/plates.test.ts
+++ b/features/programs/model/__tests__/plates.test.ts
@@ -28,11 +28,12 @@ describe("calculatePlates", () => {
 });
 
 describe("computePrescribedWeight", () => {
-  it("PR과 퍼센트를 곱하고 0.5kg 단위로 반올림한다", () => {
+  it("PR과 퍼센트를 곱하고 1kg 단위로 반올림한다", () => {
     expect(computePrescribedWeight(100, 60)).toBe(60);
     expect(computePrescribedWeight(85, 60)).toBe(51); // 51.0
     expect(computePrescribedWeight(87, 60)).toBe(52); // 52.2 → 52
     expect(computePrescribedWeight(88, 60)).toBe(53); // 52.8 → 53
+    expect(computePrescribedWeight(101, 50)).toBe(51); // 50.5 → 51 (0.5kg 단위 방지)
   });
 
   it("퍼센트가 0이면 0kg을 반환한다", () => {

--- a/features/programs/model/__tests__/plates.test.ts
+++ b/features/programs/model/__tests__/plates.test.ts
@@ -1,0 +1,41 @@
+import { calculatePlates, computePrescribedWeight } from "../plates";
+
+describe("calculatePlates", () => {
+  it("남은 무게가 0 이하이면 빈 배열을 반환한다", () => {
+    expect(calculatePlates(0)).toEqual([]);
+    expect(calculatePlates(-5)).toEqual([]);
+  });
+
+  it("한쪽 기준 무거운 플레이트부터 그리디하게 채운다", () => {
+    // 60kg: 한쪽 30kg = 25 + 5
+    expect(calculatePlates(60)).toEqual([25, 5]);
+  });
+
+  it("소수 플레이트(0.5kg)까지 활용한다", () => {
+    // 1kg: 한쪽 0.5kg
+    expect(calculatePlates(1)).toEqual([0.5]);
+  });
+
+  it("기존 계산기와 동일한 결과를 낸다 — 52kg", () => {
+    // 한쪽 26kg = 25 + 1
+    expect(calculatePlates(52)).toEqual([25, 1]);
+  });
+
+  it("기존 계산기와 동일한 결과를 낸다 — 100kg", () => {
+    // 한쪽 50kg = 25 + 25
+    expect(calculatePlates(100)).toEqual([25, 25]);
+  });
+});
+
+describe("computePrescribedWeight", () => {
+  it("PR과 퍼센트를 곱하고 0.5kg 단위로 반올림한다", () => {
+    expect(computePrescribedWeight(100, 60)).toBe(60);
+    expect(computePrescribedWeight(85, 60)).toBe(51); // 51.0
+    expect(computePrescribedWeight(87, 60)).toBe(52); // 52.2 → 52
+    expect(computePrescribedWeight(88, 60)).toBe(53); // 52.8 → 53
+  });
+
+  it("퍼센트가 0이면 0kg을 반환한다", () => {
+    expect(computePrescribedWeight(100, 0)).toBe(0);
+  });
+});

--- a/features/programs/model/__tests__/resolve-movement.test.ts
+++ b/features/programs/model/__tests__/resolve-movement.test.ts
@@ -1,0 +1,34 @@
+import { resolveRefMovement } from "../resolve-movement";
+import type { Block, Movement } from "@/features/notation/model/types";
+
+const mv = (name: string): Movement => ({ name, modifiers: [] });
+
+const blockOf = (movements: Movement[]): Block => ({
+  movements,
+  percentage: 60,
+  reps: { type: "simple", reps: 3 },
+  sets: 3,
+  modifiers: [],
+});
+
+describe("resolveRefMovement", () => {
+  it("단일 동작 블록에서는 그 동작을 반환한다", () => {
+    const block = blockOf([mv("back squat")]);
+    expect(resolveRefMovement(block).name).toBe("back squat");
+  });
+
+  it("복합(2개) 동작 블록에서는 두 번째 동작을 반환한다", () => {
+    const block = blockOf([mv("snatch pull"), mv("power snatch")]);
+    expect(resolveRefMovement(block).name).toBe("power snatch");
+  });
+
+  it("3개 이상의 복합 블록에서도 두 번째 동작을 반환한다", () => {
+    const block = blockOf([mv("a"), mv("b"), mv("c")]);
+    expect(resolveRefMovement(block).name).toBe("b");
+  });
+
+  it("동작이 비어 있으면 에러를 던진다", () => {
+    const block = blockOf([]);
+    expect(() => resolveRefMovement(block)).toThrow();
+  });
+});

--- a/features/programs/model/__tests__/resolve-weight.test.ts
+++ b/features/programs/model/__tests__/resolve-weight.test.ts
@@ -1,0 +1,94 @@
+import { resolveWeight } from "../resolve-weight";
+import type { Block, Movement } from "@/features/notation/model/types";
+
+const mv = (name: string): Movement => ({ name, modifiers: [] });
+
+const makeBlock = (
+  movements: Movement[],
+  percentage: number | null = 60
+): Block => ({
+  movements,
+  percentage,
+  reps: { type: "simple", reps: 3 },
+  sets: 3,
+  modifiers: [],
+});
+
+describe("resolveWeight", () => {
+  it("퍼센트와 PR이 모두 있으면 kg을 계산해 반환한다", () => {
+    const result = resolveWeight({
+      block: makeBlock([mv("back squat")], 70),
+      aliasMap: { "back squat": 1 },
+      prMap: { 1: 100 },
+    });
+    expect(result.kind).toBe("computed");
+    if (result.kind === "computed") {
+      expect(result.kg).toBe(70);
+      expect(result.pr).toBe(100);
+      expect(result.percentage).toBe(70);
+      expect(result.exerciseId).toBe(1);
+    }
+  });
+
+  it("퍼센트가 없으면 no-percentage를 반환한다", () => {
+    const result = resolveWeight({
+      block: makeBlock([mv("sots press")], null),
+      aliasMap: { "sots press": 2 },
+      prMap: { 2: 50 },
+    });
+    expect(result.kind).toBe("no-percentage");
+  });
+
+  it("별칭 매핑이 없으면 unresolved-alias와 동작명을 반환한다", () => {
+    const result = resolveWeight({
+      block: makeBlock([mv("P.Sn")]),
+      aliasMap: {},
+      prMap: {},
+    });
+    expect(result).toEqual({ kind: "unresolved-alias", missingName: "P.Sn" });
+  });
+
+  it("별칭은 있지만 PR이 없으면 no-pr을 반환한다", () => {
+    const result = resolveWeight({
+      block: makeBlock([mv("clean & jerk")]),
+      aliasMap: { "clean & jerk": 3 },
+      prMap: {},
+    });
+    expect(result.kind).toBe("no-pr");
+    if (result.kind === "no-pr") expect(result.exerciseId).toBe(3);
+  });
+
+  it("복합 블록에서는 두 번째 동작의 PR을 사용한다", () => {
+    const result = resolveWeight({
+      block: makeBlock([mv("snatch pull"), mv("power snatch")], 60),
+      aliasMap: { "snatch pull": 10, "power snatch": 20 },
+      prMap: { 10: 200, 20: 85 },
+    });
+    expect(result.kind).toBe("computed");
+    if (result.kind === "computed") {
+      expect(result.exerciseId).toBe(20);
+      expect(result.pr).toBe(85);
+      expect(result.kg).toBe(51); // 85 * 0.6 = 51
+    }
+  });
+
+  it("별칭 매핑은 대소문자 구분 없이 동작한다", () => {
+    const result = resolveWeight({
+      block: makeBlock([mv("BACK SQUAT")], 70),
+      aliasMap: { "back squat": 1 },
+      prMap: { 1: 100 },
+    });
+    expect(result.kind).toBe("computed");
+  });
+
+  it("결과 kg은 0.5kg 단위로 반올림된다", () => {
+    // 87 * 0.6 = 52.2 → 52
+    const result = resolveWeight({
+      block: makeBlock([mv("back squat")], 60),
+      aliasMap: { "back squat": 1 },
+      prMap: { 1: 87 },
+    });
+    expect(result.kind).toBe("computed");
+    if (result.kind === "computed") expect(result.kg).toBe(52);
+  });
+});

--- a/features/programs/model/plates.ts
+++ b/features/programs/model/plates.ts
@@ -24,9 +24,9 @@ export function calculatePlates(remainingWeight: number): Plates {
 
 /**
  * PR과 퍼센트로부터 처방 중량(kg)을 계산한다.
- * 0.5kg 단위로 반올림한다 (플레이트 최소 단위에 맞춤).
+ * 1kg 단위로 반올림한다 (양쪽 대칭 최소 단위 0.5kg × 2 = 1kg).
  */
 export function computePrescribedWeight(pr: number, percentage: number): number {
   const raw = (pr * percentage) / 100;
-  return Math.round(raw * 2) / 2;
+  return Math.round(raw);
 }

--- a/features/programs/model/plates.ts
+++ b/features/programs/model/plates.ts
@@ -1,0 +1,32 @@
+import type { Plates } from "@/types/training";
+
+const AVAILABLE_PLATES: Plates = [25, 20, 15, 10, 5, 2.5, 2, 1.5, 1, 0.5];
+
+/**
+ * 바벨을 제외한 남은 무게를 한쪽에 필요한 플레이트로 분해한다.
+ * 양쪽 대칭으로 적용되므로 한쪽 기준 무거운 플레이트부터 반환한다.
+ */
+export function calculatePlates(remainingWeight: number): Plates {
+  if (remainingWeight <= 0) return [];
+
+  let oneSideWeight = remainingWeight / 2;
+  const plates: Plates = [];
+
+  for (const plate of AVAILABLE_PLATES) {
+    while (oneSideWeight >= plate) {
+      plates.push(plate);
+      oneSideWeight -= plate;
+    }
+  }
+
+  return plates;
+}
+
+/**
+ * PR과 퍼센트로부터 처방 중량(kg)을 계산한다.
+ * 0.5kg 단위로 반올림한다 (플레이트 최소 단위에 맞춤).
+ */
+export function computePrescribedWeight(pr: number, percentage: number): number {
+  const raw = (pr * percentage) / 100;
+  return Math.round(raw * 2) / 2;
+}

--- a/features/programs/model/resolve-movement.ts
+++ b/features/programs/model/resolve-movement.ts
@@ -1,0 +1,15 @@
+import type { Block, Movement } from "@/features/notation/model/types";
+
+/**
+ * 블록의 퍼센트가 참조하는 동작을 반환한다.
+ *
+ * 복합(complex) 블록에서는 두 번째 동작의 PR이 기준이 된다는 스펙 규칙을 따른다.
+ * 예) `snatch pull & power snatch 60%` → power snatch의 PR × 60%.
+ * 단일 동작 블록에서는 그 동작 자체가 기준이다.
+ */
+export function resolveRefMovement(block: Block): Movement {
+  if (block.movements.length === 0) {
+    throw new Error("블록에 동작이 없습니다.");
+  }
+  return block.movements.length >= 2 ? block.movements[1] : block.movements[0];
+}

--- a/features/programs/model/resolve-weight.ts
+++ b/features/programs/model/resolve-weight.ts
@@ -1,0 +1,63 @@
+import type { Block } from "@/features/notation/model/types";
+import { resolveRefMovement } from "./resolve-movement";
+import { computePrescribedWeight } from "./plates";
+
+export type WeightResolution =
+  | {
+      kind: "computed";
+      kg: number;
+      pr: number;
+      percentage: number;
+      exerciseId: number;
+      refName: string;
+    }
+  | { kind: "no-percentage"; refName: string }
+  | { kind: "unresolved-alias"; missingName: string }
+  | { kind: "no-pr"; exerciseId: number; refName: string };
+
+export interface ResolveWeightInput {
+  /** parsed block from features/notation */
+  block: Block;
+  /** lowercase alias/movement-name → exerciseId */
+  aliasMap: Readonly<Record<string, number>>;
+  /** exerciseId → current PR in kg */
+  prMap: Readonly<Record<number, number>>;
+}
+
+/**
+ * 파싱된 블록 + 별칭 매핑 + PR 매핑으로 처방 중량을 해결한다.
+ * UI 계층에서 BlockCard가 어떤 상태(계산됨 / 퍼센트 없음 / 별칭 미연결 / PR 없음)인지 분기할 수 있도록
+ * 태그드 유니온으로 반환한다.
+ */
+export function resolveWeight({
+  block,
+  aliasMap,
+  prMap,
+}: ResolveWeightInput): WeightResolution {
+  const ref = resolveRefMovement(block);
+  const refName = ref.name;
+  const aliasKey = refName.trim().toLowerCase();
+  const exerciseId = aliasMap[aliasKey];
+
+  if (block.percentage === null) {
+    return { kind: "no-percentage", refName };
+  }
+
+  if (exerciseId === undefined) {
+    return { kind: "unresolved-alias", missingName: refName };
+  }
+
+  const pr = prMap[exerciseId];
+  if (pr === undefined) {
+    return { kind: "no-pr", exerciseId, refName };
+  }
+
+  return {
+    kind: "computed",
+    kg: computePrescribedWeight(pr, block.percentage),
+    pr,
+    percentage: block.percentage,
+    exerciseId,
+    refName,
+  };
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,10 +12,18 @@ module.exports = {
   collectCoverageFrom: [
     'features/notation/model/**/*.ts',
     '!features/notation/model/**/__tests__/**',
+    'features/programs/model/**/*.ts',
+    '!features/programs/model/**/__tests__/**',
     'actions/personalRecords.ts',
   ],
   coverageThreshold: {
     'features/notation/model/': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+    'features/programs/model/': {
       branches: 80,
       functions: 80,
       lines: 80,


### PR DESCRIPTION
## 배경

Phase 1C(#17)를 리뷰 가능한 크기(≤500 lines/PR)로 5개 PR로 나눈 첫 번째 조각.

Plan: `~/.claude/plans/implement-17-phase-1c-serene-fox.md`

## 범위

파싱된 노테이션 블록을 '처방 중량'으로 해석하는 **순수 로직**만 포함. UI·DB 변경 없음.

- `features/programs/model/resolve-movement.ts` — 복합 블록에서 퍼센트의 기준은 **두 번째 동작**이라는 스펙 규칙
- `features/programs/model/resolve-weight.ts` — 블록 × 별칭맵 × PR맵 → `WeightResolution` 태그드 유니온 (`computed` / `no-percentage` / `unresolved-alias` / `no-pr`)
- `features/programs/model/plates.ts` — `calculatePlates` + `computePrescribedWeight` (0.5kg 반올림)
- 기존 `weight-calculator/page.tsx`의 `calculatePlates`를 공유 모듈로 추출 후 재사용 (동작 동일)
- Jest 단위 테스트 (한글 describe/it, 커버리지 100%)

## 다음 단계 (별도 PR)

- 1C-2: `movement_aliases` 서버 액션 + `/settings/movement-aliases` UI
- 1C-3: `/training/program-input` 재작성 (노테이션 → 편집 폼 → 저장)
- 1C-4: `/training/program-runner/[id]` UI (세트 트래커 / PR Day / 오버라이드)
- 1C-5: `weight-calculator`가 인증된 사용자 PR을 조회하도록 연결

## 테스트 계획

- [x] `npm test` — 57개 통과 (기존 39 + 신규 18)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] 기존 `weight-calculator` 페이지 정상 빌드 (calculatePlates 추출 후에도 동작 동일)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 무게 계산 로직의 안정성 개선 및 0.5kg 단위의 정확한 무게 계산 지원
  * 다중 동작 포함 시 올바른 참조 동작 선택 로직 개선

* **테스트**
  * 무게 계산, 동작 해석, 무게 해석 관련 포괄적인 테스트 추가
  * 코드 품질 및 신뢰성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->