### PR TITLE
[refactor] Phase 1C-2 - movement_aliases 제거 및 exercises 기반 alias 인프라 (#17)

### DIFF
--- a/features/exercises/api/exercises.ts
+++ b/features/exercises/api/exercises.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { supabaseServerClient } from "@/features/auth/supabase/ServerClient";
+import { handleDatabaseError } from "@/utils/database";
+import type { Tables } from "@/types_db";
+
+export type ExerciseRow = Tables<"exercises">;
+
+/**
+ * 큐레이트된 exercises 세트를 반환한다 (seed 기반, 공개 SELECT RLS).
+ * resolver 의 aliasMap 과 프로그램 UI 의 exercise 선택 옵션 공급원이 된다.
+ */
+export async function listExercises(): Promise<ExerciseRow[]> {
+  const supabase = await supabaseServerClient();
+  const { data, error } = await supabase
+    .from("exercises")
+    .select("*")
+    .order("id", { ascending: true });
+
+  if (error) handleDatabaseError(error);
+  return (data ?? []) as ExerciseRow[];
+}

--- a/features/exercises/model/__tests__/build-alias-map.test.ts
+++ b/features/exercises/model/__tests__/build-alias-map.test.ts
@@ -1,0 +1,39 @@
+import { buildAliasMap } from "../build-alias-map";
+
+describe("buildAliasMap", () => {
+  it("빈 배열은 빈 객체를 반환한다", () => {
+    expect(buildAliasMap([])).toEqual({});
+  });
+
+  it("name 을 trim + lowercase 한 키로 id 를 매핑한다", () => {
+    const map = buildAliasMap([
+      { id: 1, name: "  Back Squat  " },
+      { id: 2, name: "스내치" },
+    ]);
+    expect(map).toEqual({ "back squat": 1, 스내치: 2 });
+  });
+
+  it("공백만 있는 이름은 무시한다", () => {
+    const map = buildAliasMap([
+      { id: 1, name: "   " },
+      { id: 2, name: "Deadlift" },
+    ]);
+    expect(map).toEqual({ deadlift: 2 });
+  });
+
+  it("동일 키가 여러 행에 있으면 더 작은 id 가 이긴다", () => {
+    const map = buildAliasMap([
+      { id: 5, name: "Jerk" },
+      { id: 2, name: "jerk" },
+      { id: 7, name: " JERK " },
+    ]);
+    expect(map).toEqual({ jerk: 2 });
+  });
+
+  it("입력 배열을 변형하지 않는다", () => {
+    const input = [{ id: 1, name: "Snatch" }];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    buildAliasMap(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/features/exercises/model/build-alias-map.ts
+++ b/features/exercises/model/build-alias-map.ts
@@ -1,0 +1,27 @@
+import type { Tables } from "@/types_db";
+
+export type ExerciseRow = Tables<"exercises">;
+
+/**
+ * exercises 행 배열을 resolver가 사용하는 aliasMap(소문자 이름 → id)으로 변환한다.
+ * 순수 함수: 입력을 변형하지 않는다.
+ *
+ * 규칙:
+ * - key 는 name 을 trim + lowercase
+ * - 빈 key(공백만) 는 무시
+ * - 동일 key 가 여러 행에 있을 경우 더 작은 id 가 이긴다 (결정적 결과)
+ */
+export function buildAliasMap(
+  exercises: ReadonlyArray<Pick<ExerciseRow, "id" | "name">>,
+): Record<string, number> {
+  const map: Record<string, number> = {};
+  for (const row of exercises) {
+    const key = row.name.trim().toLowerCase();
+    if (!key) continue;
+    const existing = map[key];
+    if (existing === undefined || row.id < existing) {
+      map[key] = row.id;
+    }
+  }
+  return map;
+}

--- a/features/exercises/ui/useExercises.ts
+++ b/features/exercises/ui/useExercises.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { listExercises, type ExerciseRow } from "../api/exercises";
+import { QUERY_KEYS } from "@/lib/queryKeys";
+
+export function useExercises() {
+  return useQuery<ExerciseRow[]>({
+    queryKey: [QUERY_KEYS.EXERCISES],
+    queryFn: async () => {
+      const rows = await listExercises();
+      return rows ?? [];
+    },
+    staleTime: 1000 * 60 * 60,
+  });
+}

--- a/features/notation/model/tokenizer.ts
+++ b/features/notation/model/tokenizer.ts
@@ -18,8 +18,6 @@ export interface Token {
 }
 
 const IDENT_START = /[A-Za-z\uAC00-\uD7A3]/;
-// TODO(phase1B): tighten to disallow trailing/consecutive dots (e.g., "abc.", "abc..def")
-//                once movement_aliases canonicalization rejects unknown names.
 const IDENT_CONT = /[A-Za-z\uAC00-\uD7A3.]/;
 const DIGIT = /[0-9]/;
 

--- a/supabase/migrations/20260422155733_drop_movement_aliases.sql
+++ b/supabase/migrations/20260422155733_drop_movement_aliases.sql
@@ -1,0 +1,5 @@
+-- movement_aliases 제거
+-- 사유: 파서/resolver와 연결되지 않아 사용자 설정 burden만 발생. v1은 exercises canonical 이름만 사용.
+-- 재도입 계획: 사용자 요청 누적 시 시스템 dictionary(exercise_aliases)로 대체 (Phase 2+).
+
+DROP TABLE IF EXISTS "public"."movement_aliases" CASCADE;

--- a/types_db.ts
+++ b/types_db.ts
@@ -51,38 +51,6 @@ export type Database = {
         }
         Relationships: []
       }
-      movement_aliases: {
-        Row: {
-          alias: string
-          created_at: string
-          exercise_id: number
-          id: number
-          user_id: string
-        }
-        Insert: {
-          alias: string
-          created_at?: string
-          exercise_id: number
-          id?: number
-          user_id: string
-        }
-        Update: {
-          alias?: string
-          created_at?: string
-          exercise_id?: number
-          id?: number
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "movement_aliases_exercise_id_fkey"
-            columns: ["exercise_id"]
-            isOneToOne: false
-            referencedRelation: "exercises"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       "personal-records": {
         Row: {
           created_at: string | null


### PR DESCRIPTION
## 배경

PR #20 리뷰 중 두 가지 문제 확인:

1. **기능이 파서/resolver와 분리됨** — 사용자가 `/settings/movement-aliases`에서 alias 등록해도 어디서도 호출되지 않아 파싱/저장/PR 계산에 반영 X. 설정 burden만 발생.
2. **기능이 섞여 있음** — PR %→kg 계산은 고정 8개 exercise(`pr_history.exercise_id RESTRICT`)에만 의존. 사용자별 alias 관리는 여러 체육관 사용 시 burden이 누적되는 주관적 설정.

→ PR #20 close, 본 PR에서 인프라를 **exercises 테이블 기반**으로 재구성.

## 변경 사항

- `supabase/migrations/20260422155733_drop_movement_aliases.sql` — `movement_aliases` 테이블 DROP (idempotent)
- `features/exercises/api/exercises.ts` — `listExercises` 서버 액션 (큐레이트된 8개 seed)
- `features/exercises/model/build-alias-map.ts` — 순수 함수 + 테스트
  - `exercises` 행 → `Record<string, exerciseId>` (trim + lowercase)
  - 공백/중복 key 처리, 입력 불변 보장
- `features/exercises/ui/useExercises.ts` — React Query 훅 (`QUERY_KEYS.EXERCISES`, 1h staleTime)
- `features/notation/model/tokenizer.ts` — 낡은 `movement_aliases` TODO 주석 제거
- `types_db.ts` — 로컬 스키마 기준 재생성 (`--local`)

## 재사용

- Phase 1C-1 resolver(`features/programs/model/resolve-weight.ts`)는 `aliasMap` 입력 구조 그대로. **로직 변경 없음**, 소스만 교체.

## 테스트 계획

- [x] `npx supabase db reset` → drop migration 적용 확인
- [x] `npm run generate-types:local` → `types_db.ts`에서 `movement_aliases` 제거 확인
- [x] `npm test` — 62 tests 통과 (신규 `build-alias-map` 5건 포함)
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 통과

## Follow-up (별도 이슈)

- [ ] 노테이션 입력/저장 UI(#17 Phase 1C-3/4)에서 `useExercises() → buildAliasMap() → resolveWeight()` 연결
- [ ] Unresolved movement 블록에 세션 한정 exercise 선택 드롭다운
- [ ] 사용자 alias 요청 수집 채널 설계 — 누적 시 시스템 dictionary(`exercise_aliases`)로 재도입 검토

Closes part of #17 (1C-2 인프라). #20 close 사유와 연동.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 운동 데이터 조회 기능이 추가되었습니다.
  * 운동 정보에 접근하기 위한 React 훅이 추가되었습니다.

* **테스트**
  * 별칭 매핑 함수에 대한 포괄적인 테스트가 추가되었습니다.

* **Chores**
  * 더 이상 사용하지 않는 데이터베이스 테이블과 관련 타입 정의를 제거했습니다.
  * 코드 정리 작업이 진행되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->