### PR TITLE
[feat] Training Film Mode — 프로그램 진행 중 폼 촬영 + 세트 오버레이

### DIFF
--- a/features/film/model/__tests__/codecs.test.ts
+++ b/features/film/model/__tests__/codecs.test.ts
@@ -1,0 +1,25 @@
+import { pickVideoMimeType } from "../codecs";
+
+describe("pickVideoMimeType", () => {
+  const orig = (globalThis as any).MediaRecorder;
+  afterEach(() => {
+    (globalThis as any).MediaRecorder = orig;
+  });
+
+  it("브라우저가 지원하는 첫 번째 후보를 반환한다", () => {
+    (globalThis as any).MediaRecorder = {
+      isTypeSupported: (t: string) => t === "video/mp4;codecs=h264",
+    };
+    expect(pickVideoMimeType()).toBe("video/mp4;codecs=h264");
+  });
+
+  it("어떤 후보도 지원하지 않으면 빈 문자열을 반환한다", () => {
+    (globalThis as any).MediaRecorder = { isTypeSupported: () => false };
+    expect(pickVideoMimeType()).toBe("");
+  });
+
+  it("MediaRecorder가 없는 환경에서 빈 문자열을 반환한다", () => {
+    delete (globalThis as any).MediaRecorder;
+    expect(pickVideoMimeType()).toBe("");
+  });
+});

--- a/features/film/model/__tests__/film-navigator.test.ts
+++ b/features/film/model/__tests__/film-navigator.test.ts
@@ -1,0 +1,119 @@
+import type { ExercisePosition } from "@/features/program-runner/model/types";
+import {
+  initialState,
+  canPrev,
+  canNext,
+  stepPrev,
+  stepNext,
+} from "../film-navigator";
+
+function makePosition(setCount: number): ExercisePosition {
+  return {
+    blockIdx: 0,
+    exerciseIdx: 0,
+    totalBlocks: 1,
+    totalExercises: 1,
+    blockMovements: [],
+    movement: {
+      id: "m1",
+      name: "Back Squat",
+      alias: null,
+      sets: [],
+    } as unknown as ExercisePosition["movement"],
+    sets: Array.from({ length: setCount }, (_, i) => ({
+      setNumber: i + 1,
+      totalSets: setCount,
+      percentage: null,
+      reps: { type: "simple", reps: 3 },
+      prescribedKg: null,
+    })),
+  };
+}
+
+describe("film-navigator", () => {
+  const positions = [makePosition(3), makePosition(2), makePosition(4)];
+
+  describe("initialState", () => {
+    it("지정한 positionIdx와 setIdx 0으로 초기 상태를 반환한다", () => {
+      expect(initialState(2)).toEqual({ positionIdx: 2, setIdx: 0 });
+    });
+
+    it("기본값은 positionIdx 0이다", () => {
+      expect(initialState()).toEqual({ positionIdx: 0, setIdx: 0 });
+    });
+  });
+
+  describe("canPrev", () => {
+    it("첫 번째 운동 첫 번째 세트에서 false를 반환한다", () => {
+      expect(canPrev({ positionIdx: 0, setIdx: 0 })).toBe(false);
+    });
+
+    it("세트 인덱스가 0보다 크면 true를 반환한다", () => {
+      expect(canPrev({ positionIdx: 0, setIdx: 1 })).toBe(true);
+    });
+
+    it("positionIdx가 0보다 크면 true를 반환한다", () => {
+      expect(canPrev({ positionIdx: 1, setIdx: 0 })).toBe(true);
+    });
+  });
+
+  describe("canNext", () => {
+    it("마지막 운동 마지막 세트에서 false를 반환한다", () => {
+      expect(canNext({ positionIdx: 2, setIdx: 3 }, positions)).toBe(false);
+    });
+
+    it("현재 운동에 다음 세트가 있으면 true를 반환한다", () => {
+      expect(canNext({ positionIdx: 0, setIdx: 1 }, positions)).toBe(true);
+    });
+
+    it("다음 운동이 있으면 true를 반환한다", () => {
+      expect(canNext({ positionIdx: 0, setIdx: 2 }, positions)).toBe(true);
+    });
+
+    it("positions가 빈 배열이면 false를 반환한다", () => {
+      expect(canNext({ positionIdx: 0, setIdx: 0 }, [])).toBe(false);
+    });
+  });
+
+  describe("stepPrev", () => {
+    it("같은 운동 내 이전 세트로 이동한다", () => {
+      expect(stepPrev({ positionIdx: 0, setIdx: 2 }, positions)).toEqual({
+        positionIdx: 0,
+        setIdx: 1,
+      });
+    });
+
+    it("세트 0에서 이전 운동의 마지막 세트로 이동한다", () => {
+      expect(stepPrev({ positionIdx: 1, setIdx: 0 }, positions)).toEqual({
+        positionIdx: 0,
+        setIdx: 2,
+      });
+    });
+
+    it("첫 번째 운동 첫 번째 세트에서 상태가 변경되지 않는다", () => {
+      const state = { positionIdx: 0, setIdx: 0 };
+      expect(stepPrev(state, positions)).toEqual(state);
+    });
+  });
+
+  describe("stepNext", () => {
+    it("같은 운동 내 다음 세트로 이동한다", () => {
+      expect(stepNext({ positionIdx: 0, setIdx: 0 }, positions)).toEqual({
+        positionIdx: 0,
+        setIdx: 1,
+      });
+    });
+
+    it("마지막 세트에서 다음 운동의 첫 번째 세트로 이동한다", () => {
+      expect(stepNext({ positionIdx: 0, setIdx: 2 }, positions)).toEqual({
+        positionIdx: 1,
+        setIdx: 0,
+      });
+    });
+
+    it("마지막 운동 마지막 세트에서 상태가 변경되지 않는다", () => {
+      const state = { positionIdx: 2, setIdx: 3 };
+      expect(stepNext(state, positions)).toEqual(state);
+    });
+  });
+});

--- a/features/film/model/__tests__/overlay-label.test.ts
+++ b/features/film/model/__tests__/overlay-label.test.ts
@@ -22,14 +22,24 @@ function setPlan(
 }
 
 describe("formatOverlayLabel", () => {
-  it("퍼센트가 있으면 '종목 · Set n/m · p% × r' 형식을 반환한다", () => {
-    const result = formatOverlayLabel(movement("Back Squat"), setPlan(3, 5, 2, 85));
-    expect(result).toBe("Back Squat · Set 3/5 · 85% × 2");
+  it("동작·무게·퍼센트·세트를 '종목 · kg · p% · Set n/m' 형식으로 반환한다", () => {
+    const result = formatOverlayLabel(movement("Back Squat"), setPlan(3, 5, 2, 85), 100);
+    expect(result).toBe("Back Squat · 100kg · 85% · Set 3/5");
   });
 
-  it("퍼센트가 없으면 '종목 · Set n/m · × r' 형식을 반환한다", () => {
-    const result = formatOverlayLabel(movement("Snatch"), setPlan(1, 3, 5));
-    expect(result).toBe("Snatch · Set 1/3 · × 5");
+  it("무게(kg)가 null이면 무게 부분을 생략한다", () => {
+    const result = formatOverlayLabel(movement("Snatch"), setPlan(1, 3, 5, 80), null);
+    expect(result).toBe("Snatch · 80% · Set 1/3");
+  });
+
+  it("퍼센트가 null이면 퍼센트 부분을 생략한다", () => {
+    const result = formatOverlayLabel(movement("Snatch"), setPlan(1, 3, 5), 60);
+    expect(result).toBe("Snatch · 60kg · Set 1/3");
+  });
+
+  it("무게와 퍼센트가 모두 없으면 '종목 · Set n/m'만 반환한다", () => {
+    const result = formatOverlayLabel(movement("Snatch"), setPlan(2, 4, 1), null);
+    expect(result).toBe("Snatch · Set 2/4");
   });
 
   it("before 모디파이어를 종목명 앞에 붙인다", () => {
@@ -37,8 +47,8 @@ describe("formatOverlayLabel", () => {
       name: "Clean",
       modifiers: [{ name: "Hang", position: "before" }],
     };
-    const result = formatOverlayLabel(mv, setPlan(2, 4, 3, 70));
-    expect(result).toBe("Hang Clean · Set 2/4 · 70% × 3");
+    const result = formatOverlayLabel(mv, setPlan(2, 4, 3, 70), 90);
+    expect(result).toBe("Hang Clean · 90kg · 70% · Set 2/4");
   });
 
   it("after 모디파이어를 종목명 뒤 괄호로 붙인다", () => {
@@ -46,19 +56,7 @@ describe("formatOverlayLabel", () => {
       name: "Squat",
       modifiers: [{ name: "Pause", position: "after" }],
     };
-    const result = formatOverlayLabel(mv, setPlan(1, 2, 4, 80));
-    expect(result).toBe("Squat (Pause) · Set 1/2 · 80% × 4");
-  });
-
-  it("complex rep scheme을 '+' 형식으로 표시한다", () => {
-    const set: SetPlan = {
-      setNumber: 1,
-      totalSets: 3,
-      percentage: 75,
-      reps: { type: "complex", reps: [3, 2, 1] },
-      prescribedKg: null,
-    };
-    const result = formatOverlayLabel(movement("Power Clean"), set);
-    expect(result).toBe("Power Clean · Set 1/3 · 75% × 3+2+1");
+    const result = formatOverlayLabel(mv, setPlan(1, 2, 4, 80), 120);
+    expect(result).toBe("Squat (Pause) · 120kg · 80% · Set 1/2");
   });
 });

--- a/features/film/model/__tests__/overlay-label.test.ts
+++ b/features/film/model/__tests__/overlay-label.test.ts
@@ -1,0 +1,64 @@
+import type { Movement } from "@/features/notation/model/types";
+import type { SetPlan } from "@/features/program-runner/model/types";
+import { formatOverlayLabel } from "../overlay-label";
+
+function movement(name: string): Movement {
+  return { name, modifiers: [] };
+}
+
+function setPlan(
+  setNumber: number,
+  totalSets: number,
+  reps: number,
+  percentage: number | null = null,
+): SetPlan {
+  return {
+    setNumber,
+    totalSets,
+    percentage,
+    reps: { type: "simple", reps },
+    prescribedKg: null,
+  };
+}
+
+describe("formatOverlayLabel", () => {
+  it("퍼센트가 있으면 '종목 · Set n/m · p% × r' 형식을 반환한다", () => {
+    const result = formatOverlayLabel(movement("Back Squat"), setPlan(3, 5, 2, 85));
+    expect(result).toBe("Back Squat · Set 3/5 · 85% × 2");
+  });
+
+  it("퍼센트가 없으면 '종목 · Set n/m · × r' 형식을 반환한다", () => {
+    const result = formatOverlayLabel(movement("Snatch"), setPlan(1, 3, 5));
+    expect(result).toBe("Snatch · Set 1/3 · × 5");
+  });
+
+  it("before 모디파이어를 종목명 앞에 붙인다", () => {
+    const mv: Movement = {
+      name: "Clean",
+      modifiers: [{ name: "Hang", position: "before" }],
+    };
+    const result = formatOverlayLabel(mv, setPlan(2, 4, 3, 70));
+    expect(result).toBe("Hang Clean · Set 2/4 · 70% × 3");
+  });
+
+  it("after 모디파이어를 종목명 뒤 괄호로 붙인다", () => {
+    const mv: Movement = {
+      name: "Squat",
+      modifiers: [{ name: "Pause", position: "after" }],
+    };
+    const result = formatOverlayLabel(mv, setPlan(1, 2, 4, 80));
+    expect(result).toBe("Squat (Pause) · Set 1/2 · 80% × 4");
+  });
+
+  it("complex rep scheme을 '+' 형식으로 표시한다", () => {
+    const set: SetPlan = {
+      setNumber: 1,
+      totalSets: 3,
+      percentage: 75,
+      reps: { type: "complex", reps: [3, 2, 1] },
+      prescribedKg: null,
+    };
+    const result = formatOverlayLabel(movement("Power Clean"), set);
+    expect(result).toBe("Power Clean · Set 1/3 · 75% × 3+2+1");
+  });
+});

--- a/features/film/model/__tests__/save-to-gallery.test.ts
+++ b/features/film/model/__tests__/save-to-gallery.test.ts
@@ -1,0 +1,171 @@
+import { saveToGallery } from "../save-to-gallery";
+
+function makeBlob(type = "video/mp4"): Blob {
+  return new Blob(["fake-video-data"], { type });
+}
+
+describe("saveToGallery", () => {
+  const origShare = (globalThis as any).navigator?.share;
+  const origCanShare = (globalThis as any).navigator?.canShare;
+  const origCreateObjectURL = (globalThis as any).URL?.createObjectURL;
+  const origRevokeObjectURL = (globalThis as any).URL?.revokeObjectURL;
+
+  beforeEach(() => {
+    if (!("URL" in globalThis)) {
+      (globalThis as any).URL = {};
+    }
+    (globalThis as any).URL.createObjectURL = jest.fn(() => "blob:fake-url");
+    (globalThis as any).URL.revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
+    const nav = (globalThis as any).navigator ?? {};
+    nav.share = origShare;
+    nav.canShare = origCanShare;
+    if (origCreateObjectURL !== undefined) {
+      (globalThis as any).URL.createObjectURL = origCreateObjectURL;
+    }
+    if (origRevokeObjectURL !== undefined) {
+      (globalThis as any).URL.revokeObjectURL = origRevokeObjectURL;
+    }
+    jest.restoreAllMocks();
+  });
+
+  function setNavigatorShare(
+    shareFn: jest.Mock | undefined,
+    canShareFn: jest.Mock | undefined
+  ) {
+    if (!(globalThis as any).navigator) {
+      Object.defineProperty(globalThis, "navigator", {
+        value: {},
+        configurable: true,
+        writable: true,
+      });
+    }
+    Object.defineProperty((globalThis as any).navigator, "share", {
+      value: shareFn,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty((globalThis as any).navigator, "canShare", {
+      value: canShareFn,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  describe("Web Share API 사용 가능한 환경", () => {
+    let shareMock: jest.Mock;
+
+    beforeEach(() => {
+      shareMock = jest.fn().mockResolvedValue(undefined);
+      setNavigatorShare(shareMock, jest.fn().mockReturnValue(true));
+    });
+
+    it("mp4 Blob을 File로 변환해 navigator.share를 호출한다", async () => {
+      const blob = makeBlob("video/mp4");
+      await saveToGallery(blob, "mp4");
+
+      expect(shareMock).toHaveBeenCalledTimes(1);
+      const callArg = shareMock.mock.calls[0][0];
+      expect(callArg.files).toHaveLength(1);
+      expect(callArg.files[0]).toBeInstanceOf(File);
+      expect(callArg.files[0].name).toMatch(/\.mp4$/);
+      expect(callArg.files[0].type).toBe("video/mp4");
+    });
+
+    it("webm Blob은 .webm 확장자 File로 변환한다", async () => {
+      const blob = makeBlob("video/webm");
+      await saveToGallery(blob, "webm");
+
+      const callArg = shareMock.mock.calls[0][0];
+      expect(callArg.files[0].name).toMatch(/\.webm$/);
+    });
+  });
+
+  describe("Web Share API 미지원 환경 (폴백)", () => {
+    let clickSpy: jest.Mock;
+    let appendChildSpy: jest.SpyInstance;
+    let removeChildSpy: jest.SpyInstance;
+    let createElementSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      setNavigatorShare(undefined, undefined);
+
+      clickSpy = jest.fn();
+      const fakeAnchor = {
+        click: clickSpy,
+        href: "",
+        download: "",
+      };
+
+      if (!(globalThis as any).document) {
+        (globalThis as any).document = {
+          createElement: jest.fn(() => fakeAnchor),
+          body: {
+            appendChild: jest.fn((n: unknown) => n),
+            removeChild: jest.fn((n: unknown) => n),
+          },
+        };
+      } else {
+        createElementSpy = jest
+          .spyOn(document, "createElement")
+          .mockReturnValue(fakeAnchor as any);
+        appendChildSpy = jest
+          .spyOn(document.body, "appendChild")
+          .mockImplementation((n) => n);
+        removeChildSpy = jest
+          .spyOn(document.body, "removeChild")
+          .mockImplementation((n) => n);
+      }
+    });
+
+    afterEach(() => {
+      createElementSpy?.mockRestore();
+      appendChildSpy?.mockRestore();
+      removeChildSpy?.mockRestore();
+    });
+
+    it("다운로드 링크를 클릭해 파일을 저장한다", async () => {
+      const blob = makeBlob("video/mp4");
+      await saveToGallery(blob, "mp4");
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("링크 클릭 후 object URL을 해제한다", async () => {
+      const blob = makeBlob("video/mp4");
+      await saveToGallery(blob, "mp4");
+
+      expect((globalThis as any).URL.revokeObjectURL).toHaveBeenCalledWith(
+        "blob:fake-url"
+      );
+    });
+  });
+
+  describe("navigator.share가 실패하는 경우", () => {
+    it("AbortError는 조용히 무시한다 (사용자가 공유 취소)", async () => {
+      const abortError = Object.assign(new Error("share aborted"), {
+        name: "AbortError",
+      });
+      setNavigatorShare(
+        jest.fn().mockRejectedValue(abortError),
+        jest.fn().mockReturnValue(true)
+      );
+
+      await expect(saveToGallery(makeBlob(), "mp4")).resolves.toBeUndefined();
+    });
+
+    it("그 외 에러는 re-throw한다", async () => {
+      const netError = new Error("network error");
+      setNavigatorShare(
+        jest.fn().mockRejectedValue(netError),
+        jest.fn().mockReturnValue(true)
+      );
+
+      await expect(saveToGallery(makeBlob(), "mp4")).rejects.toThrow(
+        "network error"
+      );
+    });
+  });
+});

--- a/features/film/model/__tests__/save-to-gallery.test.ts
+++ b/features/film/model/__tests__/save-to-gallery.test.ts
@@ -4,30 +4,42 @@ function makeBlob(type = "video/mp4"): Blob {
   return new Blob(["fake-video-data"], { type });
 }
 
+function makeClickSpy() {
+  return jest.fn();
+}
+
 describe("saveToGallery", () => {
-  const origShare = (globalThis as any).navigator?.share;
-  const origCanShare = (globalThis as any).navigator?.canShare;
-  const origCreateObjectURL = (globalThis as any).URL?.createObjectURL;
-  const origRevokeObjectURL = (globalThis as any).URL?.revokeObjectURL;
+  let clickSpy: jest.Mock;
 
   beforeEach(() => {
+    jest.useFakeTimers();
+
     if (!("URL" in globalThis)) {
       (globalThis as any).URL = {};
     }
     (globalThis as any).URL.createObjectURL = jest.fn(() => "blob:fake-url");
     (globalThis as any).URL.revokeObjectURL = jest.fn();
+
+    clickSpy = makeClickSpy();
+    const fakeAnchor = { click: clickSpy, href: "", download: "" };
+    if (!(globalThis as any).document) {
+      (globalThis as any).document = {
+        createElement: () => fakeAnchor,
+        body: {
+          appendChild: jest.fn((n: unknown) => n),
+          removeChild: jest.fn((n: unknown) => n),
+        },
+      };
+    } else {
+      jest.spyOn(document, "createElement").mockReturnValue(fakeAnchor as any);
+      jest.spyOn(document.body, "appendChild").mockImplementation((n) => n);
+      jest.spyOn(document.body, "removeChild").mockImplementation((n) => n);
+    }
   });
 
   afterEach(() => {
-    const nav = (globalThis as any).navigator ?? {};
-    nav.share = origShare;
-    nav.canShare = origCanShare;
-    if (origCreateObjectURL !== undefined) {
-      (globalThis as any).URL.createObjectURL = origCreateObjectURL;
-    }
-    if (origRevokeObjectURL !== undefined) {
-      (globalThis as any).URL.revokeObjectURL = origRevokeObjectURL;
-    }
+    jest.runAllTimers();
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -63,79 +75,38 @@ describe("saveToGallery", () => {
     });
 
     it("mp4 Blob을 File로 변환해 navigator.share를 호출한다", async () => {
-      const blob = makeBlob("video/mp4");
-      await saveToGallery(blob, "mp4");
+      await saveToGallery(makeBlob("video/mp4"), "mp4");
 
       expect(shareMock).toHaveBeenCalledTimes(1);
-      const callArg = shareMock.mock.calls[0][0];
-      expect(callArg.files).toHaveLength(1);
-      expect(callArg.files[0]).toBeInstanceOf(File);
-      expect(callArg.files[0].name).toMatch(/\.mp4$/);
-      expect(callArg.files[0].type).toBe("video/mp4");
+      const { files } = shareMock.mock.calls[0][0];
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(File);
+      expect(files[0].name).toMatch(/\.mp4$/);
+      expect(files[0].type).toBe("video/mp4");
     });
 
     it("webm Blob은 .webm 확장자 File로 변환한다", async () => {
-      const blob = makeBlob("video/webm");
-      await saveToGallery(blob, "webm");
+      await saveToGallery(makeBlob("video/webm"), "webm");
 
-      const callArg = shareMock.mock.calls[0][0];
-      expect(callArg.files[0].name).toMatch(/\.webm$/);
+      const { files } = shareMock.mock.calls[0][0];
+      expect(files[0].name).toMatch(/\.webm$/);
     });
   });
 
   describe("Web Share API 미지원 환경 (폴백)", () => {
-    let clickSpy: jest.Mock;
-    let appendChildSpy: jest.SpyInstance;
-    let removeChildSpy: jest.SpyInstance;
-    let createElementSpy: jest.SpyInstance;
-
     beforeEach(() => {
       setNavigatorShare(undefined, undefined);
-
-      clickSpy = jest.fn();
-      const fakeAnchor = {
-        click: clickSpy,
-        href: "",
-        download: "",
-      };
-
-      if (!(globalThis as any).document) {
-        (globalThis as any).document = {
-          createElement: jest.fn(() => fakeAnchor),
-          body: {
-            appendChild: jest.fn((n: unknown) => n),
-            removeChild: jest.fn((n: unknown) => n),
-          },
-        };
-      } else {
-        createElementSpy = jest
-          .spyOn(document, "createElement")
-          .mockReturnValue(fakeAnchor as any);
-        appendChildSpy = jest
-          .spyOn(document.body, "appendChild")
-          .mockImplementation((n) => n);
-        removeChildSpy = jest
-          .spyOn(document.body, "removeChild")
-          .mockImplementation((n) => n);
-      }
-    });
-
-    afterEach(() => {
-      createElementSpy?.mockRestore();
-      appendChildSpy?.mockRestore();
-      removeChildSpy?.mockRestore();
     });
 
     it("다운로드 링크를 클릭해 파일을 저장한다", async () => {
-      const blob = makeBlob("video/mp4");
-      await saveToGallery(blob, "mp4");
+      await saveToGallery(makeBlob("video/mp4"), "mp4");
 
       expect(clickSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("링크 클릭 후 object URL을 해제한다", async () => {
-      const blob = makeBlob("video/mp4");
-      await saveToGallery(blob, "mp4");
+    it("링크 클릭 후 타이머 실행 시 object URL을 해제한다", async () => {
+      await saveToGallery(makeBlob("video/mp4"), "mp4");
+      jest.runAllTimers();
 
       expect((globalThis as any).URL.revokeObjectURL).toHaveBeenCalledWith(
         "blob:fake-url"
@@ -154,18 +125,32 @@ describe("saveToGallery", () => {
       );
 
       await expect(saveToGallery(makeBlob(), "mp4")).resolves.toBeUndefined();
+      expect(clickSpy).not.toHaveBeenCalled();
     });
 
-    it("그 외 에러는 re-throw한다", async () => {
-      const netError = new Error("network error");
+    it("AbortError 외 에러(NotAllowedError 등)는 downloadFile 폴백으로 전환한다", async () => {
+      const notAllowedError = Object.assign(new Error("not allowed"), {
+        name: "NotAllowedError",
+      });
       setNavigatorShare(
-        jest.fn().mockRejectedValue(netError),
+        jest.fn().mockRejectedValue(notAllowedError),
         jest.fn().mockReturnValue(true)
       );
 
-      await expect(saveToGallery(makeBlob(), "mp4")).rejects.toThrow(
-        "network error"
+      await expect(saveToGallery(makeBlob(), "mp4")).resolves.toBeUndefined();
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("canShare가 throw하면 downloadFile 폴백으로 전환한다", async () => {
+      setNavigatorShare(
+        jest.fn(),
+        jest.fn().mockImplementation(() => {
+          throw new TypeError("canShare error");
+        })
       );
+
+      await expect(saveToGallery(makeBlob(), "mp4")).resolves.toBeUndefined();
+      expect(clickSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/features/film/model/__tests__/use-camera.test.ts
+++ b/features/film/model/__tests__/use-camera.test.ts
@@ -1,0 +1,211 @@
+import { startStream, stopStream, startRecording } from "../use-camera";
+
+function createMockTrack() {
+  return { stop: jest.fn(), enabled: true };
+}
+
+function createMockStream(
+  ...tracks: ReturnType<typeof createMockTrack>[]
+): MediaStream {
+  return { getTracks: () => tracks } as unknown as MediaStream;
+}
+
+describe("startStream", () => {
+  let getUserMediaMock: jest.Mock;
+
+  beforeEach(() => {
+    getUserMediaMock = jest.fn();
+    Object.defineProperty(globalThis, "navigator", {
+      value: { mediaDevices: { getUserMedia: getUserMediaMock } },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("기본값으로 후면 카메라 스트림을 요청한다", async () => {
+    const mockStream = createMockStream(createMockTrack());
+    getUserMediaMock.mockResolvedValue(mockStream);
+
+    const result = await startStream();
+
+    expect(getUserMediaMock).toHaveBeenCalledWith({
+      video: { facingMode: "environment" },
+    });
+    expect(result).toBe(mockStream);
+  });
+
+  it("user facingMode을 지정하면 전면 카메라를 요청한다", async () => {
+    const mockStream = createMockStream(createMockTrack());
+    getUserMediaMock.mockResolvedValue(mockStream);
+
+    await startStream("user");
+
+    expect(getUserMediaMock).toHaveBeenCalledWith({
+      video: { facingMode: "user" },
+    });
+  });
+
+  it("권한이 거부되면 에러를 그대로 throw한다", async () => {
+    const permissionError = Object.assign(new Error("permission denied"), {
+      name: "NotAllowedError",
+    });
+    getUserMediaMock.mockRejectedValue(permissionError);
+
+    await expect(startStream()).rejects.toMatchObject({
+      name: "NotAllowedError",
+    });
+  });
+
+  it("mediaDevices를 지원하지 않는 환경에서 에러를 throw한다", async () => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(startStream()).rejects.toThrow();
+  });
+});
+
+describe("stopStream", () => {
+  it("스트림의 모든 트랙을 정지한다", () => {
+    const track1 = createMockTrack();
+    const track2 = createMockTrack();
+    const stream = createMockStream(track1, track2);
+
+    stopStream(stream);
+
+    expect(track1.stop).toHaveBeenCalledTimes(1);
+    expect(track2.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("트랙이 없는 스트림도 에러 없이 처리한다", () => {
+    const stream = createMockStream();
+
+    expect(() => stopStream(stream)).not.toThrow();
+  });
+});
+
+describe("startRecording", () => {
+  let MockMediaRecorder: jest.Mock;
+  let mockRecorderInstance: {
+    start: jest.Mock;
+    stop: jest.Mock;
+    ondataavailable: ((e: { data: Blob }) => void) | null;
+    onstop: (() => void) | null;
+    onerror: ((e: Event) => void) | null;
+    state: string;
+    mimeType: string;
+  };
+
+  beforeEach(() => {
+    mockRecorderInstance = {
+      start: jest.fn(),
+      stop: jest.fn(),
+      ondataavailable: null,
+      onstop: null,
+      onerror: null,
+      state: "recording",
+      mimeType: "video/mp4",
+    };
+    MockMediaRecorder = jest.fn().mockImplementation(() => mockRecorderInstance);
+    (globalThis as unknown as Record<string, unknown>).MediaRecorder =
+      MockMediaRecorder;
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as Record<string, unknown>).MediaRecorder;
+  });
+
+  it("지정된 mimeType으로 MediaRecorder를 생성하고 녹화를 시작한다", () => {
+    const stream = {} as MediaStream;
+
+    startRecording(stream, "video/mp4");
+
+    expect(MockMediaRecorder).toHaveBeenCalledWith(stream, {
+      mimeType: "video/mp4",
+    });
+    expect(mockRecorderInstance.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("mimeType이 빈 문자열이면 mimeType 옵션 없이 MediaRecorder를 생성한다", () => {
+    const stream = {} as MediaStream;
+
+    startRecording(stream, "");
+
+    expect(MockMediaRecorder).toHaveBeenCalledWith(stream, {});
+  });
+
+  function triggerStop() {
+    mockRecorderInstance.stop.mockImplementationOnce(() => {
+      mockRecorderInstance.state = "inactive";
+      mockRecorderInstance.onstop?.();
+    });
+  }
+
+  it("stop() 호출 시 수집된 chunks를 Blob으로 반환한다", async () => {
+    const stream = {} as MediaStream;
+    const handle = startRecording(stream, "video/mp4");
+
+    mockRecorderInstance.ondataavailable!({ data: new Blob(["chunk-data"]) });
+
+    triggerStop();
+    const blob = await handle.stop();
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("video/mp4");
+  });
+
+  it("size가 0인 빈 chunk는 무시하고 Blob을 반환한다", async () => {
+    const stream = {} as MediaStream;
+    const handle = startRecording(stream, "video/mp4");
+
+    mockRecorderInstance.ondataavailable!({ data: new Blob([]) });
+
+    triggerStop();
+    const blob = await handle.stop();
+
+    expect(blob.size).toBe(0);
+  });
+
+  it("stop() 이전에 수집된 모든 chunks가 하나의 Blob으로 합쳐진다", async () => {
+    const stream = {} as MediaStream;
+    const handle = startRecording(stream, "video/webm");
+
+    mockRecorderInstance.ondataavailable!({ data: new Blob(["part1"]) });
+    mockRecorderInstance.ondataavailable!({ data: new Blob(["part2"]) });
+
+    triggerStop();
+    const blob = await handle.stop();
+
+    expect(blob.size).toBeGreaterThan(0);
+    expect(blob.type).toBe("video/webm");
+  });
+
+  it("recorder가 이미 inactive 상태이면 stop()은 즉시 빈 Blob을 반환한다", async () => {
+    const stream = {} as MediaStream;
+    const handle = startRecording(stream, "video/mp4");
+
+    mockRecorderInstance.state = "inactive";
+
+    const blob = await handle.stop();
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(mockRecorderInstance.stop).not.toHaveBeenCalledTimes(2);
+  });
+
+  it("onerror 발생 시 stop()이 reject된다", async () => {
+    const stream = {} as MediaStream;
+    const handle = startRecording(stream, "video/mp4");
+
+    mockRecorderInstance.stop.mockImplementationOnce(() => {
+      mockRecorderInstance.onerror!(new Event("error"));
+    });
+
+    await expect(handle.stop()).rejects.toThrow("MediaRecorder error");
+  });
+});

--- a/features/film/model/codecs.ts
+++ b/features/film/model/codecs.ts
@@ -1,0 +1,19 @@
+const CANDIDATES: readonly string[] = [
+  "video/mp4;codecs=h264",
+  "video/mp4",
+  "video/webm;codecs=vp9",
+  "video/webm;codecs=vp8",
+  "video/webm",
+];
+
+export function pickVideoMimeType(): string {
+  if (typeof MediaRecorder === "undefined") return "";
+  for (const type of CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(type)) return type;
+  }
+  return "";
+}
+
+export function extensionFor(mime: string): "mp4" | "webm" {
+  return mime.includes("mp4") ? "mp4" : "webm";
+}

--- a/features/film/model/film-navigator.ts
+++ b/features/film/model/film-navigator.ts
@@ -1,0 +1,58 @@
+import type { ExercisePosition } from "@/features/program-runner/model/types";
+
+export interface FilmNavigatorState {
+  positionIdx: number;
+  setIdx: number;
+}
+
+export function initialState(initialPositionIdx = 0): FilmNavigatorState {
+  return { positionIdx: initialPositionIdx, setIdx: 0 };
+}
+
+export function canPrev(state: FilmNavigatorState): boolean {
+  return state.positionIdx > 0 || state.setIdx > 0;
+}
+
+export function canNext(
+  state: FilmNavigatorState,
+  positions: ExercisePosition[]
+): boolean {
+  const pos = positions[state.positionIdx];
+  if (!pos) return false;
+  const isLastSet = state.setIdx >= pos.sets.length - 1;
+  const isLastPosition = state.positionIdx >= positions.length - 1;
+  return !isLastSet || !isLastPosition;
+}
+
+export function stepPrev(
+  state: FilmNavigatorState,
+  positions: ExercisePosition[]
+): FilmNavigatorState {
+  if (state.setIdx > 0) {
+    return { ...state, setIdx: state.setIdx - 1 };
+  }
+  if (state.positionIdx > 0) {
+    const prevPosIdx = state.positionIdx - 1;
+    const prevPos = positions[prevPosIdx];
+    return {
+      positionIdx: prevPosIdx,
+      setIdx: Math.max(0, (prevPos?.sets.length ?? 1) - 1),
+    };
+  }
+  return state;
+}
+
+export function stepNext(
+  state: FilmNavigatorState,
+  positions: ExercisePosition[]
+): FilmNavigatorState {
+  const pos = positions[state.positionIdx];
+  if (!pos) return state;
+  if (state.setIdx < pos.sets.length - 1) {
+    return { ...state, setIdx: state.setIdx + 1 };
+  }
+  if (state.positionIdx < positions.length - 1) {
+    return { positionIdx: state.positionIdx + 1, setIdx: 0 };
+  }
+  return state;
+}

--- a/features/film/model/overlay-label.ts
+++ b/features/film/model/overlay-label.ts
@@ -1,0 +1,23 @@
+import type { Movement } from "@/features/notation/model/types";
+import type { SetPlan } from "@/features/program-runner/model/types";
+import { formatMovementName, formatReps } from "@/features/program-runner/model/format";
+
+/** `Back Squat · Set 3/5 · 85% × 2` 형식의 오버레이 라벨을 반환한다. */
+export function formatOverlayLabel(movement: Movement, set: SetPlan): string {
+  const { name, before, after } = formatMovementName(movement);
+
+  const displayName = [
+    before.join(" "),
+    name,
+    after.length > 0 ? `(${after.join(", ")})` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const setLabel = `Set ${set.setNumber}/${set.totalSets}`;
+  const repsLabel = `× ${formatReps(set.reps)}`;
+  const weightLabel =
+    set.percentage != null ? `${set.percentage}% ${repsLabel}` : repsLabel;
+
+  return `${displayName} · ${setLabel} · ${weightLabel}`;
+}

--- a/features/film/model/overlay-label.ts
+++ b/features/film/model/overlay-label.ts
@@ -1,9 +1,17 @@
 import type { Movement } from "@/features/notation/model/types";
 import type { SetPlan } from "@/features/program-runner/model/types";
-import { formatMovementName, formatReps } from "@/features/program-runner/model/format";
+import { formatMovementName } from "@/features/program-runner/model/format";
 
-/** `Back Squat · Set 3/5 · 85% × 2` 형식의 오버레이 라벨을 반환한다. */
-export function formatOverlayLabel(movement: Movement, set: SetPlan): string {
+/**
+ * `Snatch · 100kg · 80% · Set 1/3` 형식의 오버레이 라벨을 반환한다.
+ * 촬영 영상 라벨용 — 동작/무게가 핵심이며 반복수는 표시하지 않는다.
+ * @param kg 해당 세트의 무게(kg). null이면 생략한다.
+ */
+export function formatOverlayLabel(
+  movement: Movement,
+  set: SetPlan,
+  kg: number | null,
+): string {
   const { name, before, after } = formatMovementName(movement);
 
   const displayName = [
@@ -14,10 +22,12 @@ export function formatOverlayLabel(movement: Movement, set: SetPlan): string {
     .filter(Boolean)
     .join(" ");
 
-  const setLabel = `Set ${set.setNumber}/${set.totalSets}`;
-  const repsLabel = `× ${formatReps(set.reps)}`;
-  const weightLabel =
-    set.percentage != null ? `${set.percentage}% ${repsLabel}` : repsLabel;
-
-  return `${displayName} · ${setLabel} · ${weightLabel}`;
+  return [
+    displayName,
+    kg != null ? `${kg}kg` : "",
+    set.percentage != null ? `${set.percentage}%` : "",
+    `Set ${set.setNumber}/${set.totalSets}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }

--- a/features/film/model/save-to-gallery.ts
+++ b/features/film/model/save-to-gallery.ts
@@ -1,0 +1,48 @@
+type VideoExtension = "mp4" | "webm";
+
+function buildFileName(ext: VideoExtension): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  return `yeokdo-${ts}.${ext}`;
+}
+
+function canUseShareApi(file: File): boolean {
+  return (
+    typeof navigator.share === "function" &&
+    typeof navigator.canShare === "function" &&
+    navigator.canShare({ files: [file] })
+  );
+}
+
+async function shareFile(file: File): Promise<void> {
+  try {
+    await navigator.share({ files: [file] });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === "AbortError") return;
+    throw err;
+  }
+}
+
+function downloadFile(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export async function saveToGallery(
+  blob: Blob,
+  ext: VideoExtension
+): Promise<void> {
+  const fileName = buildFileName(ext);
+  const file = new File([blob], fileName, { type: blob.type });
+
+  if (canUseShareApi(file)) {
+    await shareFile(file);
+  } else {
+    downloadFile(blob, fileName);
+  }
+}

--- a/features/film/model/save-to-gallery.ts
+++ b/features/film/model/save-to-gallery.ts
@@ -6,20 +6,19 @@ function buildFileName(ext: VideoExtension): string {
 }
 
 function canUseShareApi(file: File): boolean {
-  return (
-    typeof navigator.share === "function" &&
-    typeof navigator.canShare === "function" &&
-    navigator.canShare({ files: [file] })
-  );
+  try {
+    return (
+      typeof navigator.share === "function" &&
+      typeof navigator.canShare === "function" &&
+      navigator.canShare({ files: [file] })
+    );
+  } catch {
+    return false;
+  }
 }
 
 async function shareFile(file: File): Promise<void> {
-  try {
-    await navigator.share({ files: [file] });
-  } catch (err: unknown) {
-    if (err instanceof Error && err.name === "AbortError") return;
-    throw err;
-  }
+  await navigator.share({ files: [file] });
 }
 
 function downloadFile(blob: Blob, fileName: string): void {
@@ -30,7 +29,7 @@ function downloadFile(blob: Blob, fileName: string): void {
   document.body.appendChild(anchor);
   anchor.click();
   document.body.removeChild(anchor);
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 export async function saveToGallery(
@@ -41,8 +40,12 @@ export async function saveToGallery(
   const file = new File([blob], fileName, { type: blob.type });
 
   if (canUseShareApi(file)) {
-    await shareFile(file);
-  } else {
-    downloadFile(blob, fileName);
+    try {
+      await shareFile(file);
+      return;
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "AbortError") return;
+    }
   }
+  downloadFile(blob, fileName);
 }

--- a/features/film/model/use-camera.ts
+++ b/features/film/model/use-camera.ts
@@ -1,0 +1,47 @@
+export type FacingMode = "user" | "environment";
+
+export type RecordingHandle = {
+  stop: () => Promise<Blob>;
+};
+
+export async function startStream(
+  facingMode: FacingMode = "environment"
+): Promise<MediaStream> {
+  return navigator.mediaDevices.getUserMedia({ video: { facingMode } });
+}
+
+export function stopStream(stream: MediaStream): void {
+  stream.getTracks().forEach((track) => track.stop());
+}
+
+export function startRecording(
+  stream: MediaStream,
+  mimeType: string
+): RecordingHandle {
+  const chunks: Blob[] = [];
+  const options = mimeType ? { mimeType } : {};
+  const recorder = new MediaRecorder(stream, options);
+
+  recorder.ondataavailable = (e: BlobEvent) => {
+    if (e.data.size > 0) chunks.push(e.data);
+  };
+
+  recorder.start();
+
+  return {
+    stop: () =>
+      new Promise((resolve, reject) => {
+        if (recorder.state === "inactive") {
+          resolve(new Blob(chunks, { type: mimeType }));
+          return;
+        }
+        recorder.onstop = () => {
+          resolve(new Blob(chunks, { type: mimeType }));
+        };
+        recorder.onerror = () => {
+          reject(new Error("MediaRecorder error"));
+        };
+        recorder.stop();
+      }),
+  };
+}

--- a/features/film/ui/CameraPane.tsx
+++ b/features/film/ui/CameraPane.tsx
@@ -123,7 +123,7 @@ export function CameraPane({
         autoPlay
         playsInline
         muted
-        aria-label="카메라 프리뷰"
+        aria-label="Camera preview"
       />
 
       {/* 상단 버튼 영역 */}
@@ -132,7 +132,7 @@ export function CameraPane({
           type="button"
           onClick={onFlip}
           disabled={recording}
-          aria-label="카메라 전환"
+          aria-label="Switch camera"
           className="flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white disabled:opacity-30"
         >
           <FlipHorizontal2 className="h-5 w-5" />
@@ -141,7 +141,7 @@ export function CameraPane({
         <button
           type="button"
           onClick={handleCloseRequest}
-          aria-label="촬영 종료"
+          aria-label="Close camera"
           className="flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white"
         >
           <X className="h-5 w-5" />
@@ -161,7 +161,7 @@ export function CameraPane({
         <button
           type="button"
           onClick={handleToggleRecording}
-          aria-label={recording ? "녹화 중지" : "녹화 시작"}
+          aria-label={recording ? "Stop recording" : "Record"}
           className="flex h-16 w-16 items-center justify-center rounded-full bg-white shadow-lg active:scale-95"
         >
           {recording ? (

--- a/features/film/ui/CameraPane.tsx
+++ b/features/film/ui/CameraPane.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { X, FlipHorizontal2, Circle, Square } from "lucide-react";
+
+import type { RecordingHandle } from "../model/use-camera";
+import { startRecording } from "../model/use-camera";
+import { extensionFor } from "../model/codecs";
+import { saveToGallery } from "../model/save-to-gallery";
+
+interface CameraPaneProps {
+  stream: MediaStream | null;
+  mimeType: string;
+  onFlip: () => void;
+  onClose: () => void;
+  onSaveError?: (err: unknown) => void;
+  children?: React.ReactNode;
+}
+
+export function CameraPane({
+  stream,
+  mimeType,
+  onFlip,
+  onClose,
+  onSaveError,
+  children,
+}: CameraPaneProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [recording, setRecording] = useState(false);
+  const [closePending, setClosePending] = useState(false);
+  // handleRef: recording 중 ref로 관리해 상태와 분리 — race condition 방지
+  const handleRef = useRef<RecordingHandle | null>(null);
+  // 이중 탭 방지: toggle 처리 중 flag
+  const togglingRef = useRef(false);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (!stream) {
+      video.pause();
+      video.srcObject = null;
+      return;
+    }
+    video.srcObject = stream;
+    video.play().catch(() => {});
+  }, [stream]);
+
+  // 페이지 이탈 시 녹화 중 경고
+  useEffect(() => {
+    if (!recording) return;
+    const guard = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", guard);
+    return () => window.removeEventListener("beforeunload", guard);
+  }, [recording]);
+
+  // unmount 시 active MediaRecorder 정리
+  useEffect(() => {
+    return () => {
+      handleRef.current?.stop().catch(() => {});
+      handleRef.current = null;
+    };
+  }, []);
+
+  async function handleToggleRecording() {
+    if (togglingRef.current) return;
+    togglingRef.current = true;
+
+    try {
+      if (!handleRef.current) {
+        if (!stream) return;
+        handleRef.current = startRecording(stream, mimeType);
+        setRecording(true);
+        return;
+      }
+
+      const handle = handleRef.current;
+      handleRef.current = null;
+      setRecording(false);
+      try {
+        const blob = await handle.stop();
+        await saveToGallery(blob, extensionFor(mimeType));
+      } catch (err) {
+        onSaveError?.(err);
+      }
+    } finally {
+      togglingRef.current = false;
+    }
+  }
+
+  function handleCloseRequest() {
+    if (recording) {
+      setClosePending(true);
+    } else {
+      onClose();
+    }
+  }
+
+  async function handleConfirmClose() {
+    setClosePending(false);
+    const handle = handleRef.current;
+    handleRef.current = null;
+    setRecording(false);
+    // stop()을 await해 MediaRecorder가 flush할 시간을 준 뒤 닫기
+    if (handle) await handle.stop().catch(() => {});
+    onClose();
+  }
+
+  function handleCancelClose() {
+    setClosePending(false);
+  }
+
+  return (
+    <div className="relative h-full w-full overflow-hidden bg-black">
+      <video
+        ref={videoRef}
+        className="h-full w-full object-cover"
+        autoPlay
+        playsInline
+        muted
+        aria-label="카메라 프리뷰"
+      />
+
+      {/* 상단 버튼 영역 */}
+      <div className="absolute left-0 right-0 top-0 flex items-center justify-between p-4">
+        <button
+          type="button"
+          onClick={onFlip}
+          disabled={recording}
+          aria-label="카메라 전환"
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white disabled:opacity-30"
+        >
+          <FlipHorizontal2 className="h-5 w-5" />
+        </button>
+
+        <button
+          type="button"
+          onClick={handleCloseRequest}
+          aria-label="촬영 종료"
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* ProgramOverlay 슬롯 */}
+      {children}
+
+      {/* REC 버튼 */}
+      <div className="absolute bottom-8 left-1/2 flex -translate-x-1/2 flex-col items-center gap-2">
+        {recording ? (
+          <span className="text-xs font-bold tracking-widest text-red-500">
+            ● REC
+          </span>
+        ) : null}
+        <button
+          type="button"
+          onClick={handleToggleRecording}
+          aria-label={recording ? "녹화 중지" : "녹화 시작"}
+          className="flex h-16 w-16 items-center justify-center rounded-full bg-white shadow-lg active:scale-95"
+        >
+          {recording ? (
+            <Square className="h-7 w-7 fill-red-600 text-red-600" />
+          ) : (
+            <Circle className="h-7 w-7 fill-red-500 text-red-500" />
+          )}
+        </button>
+      </div>
+
+      {/* 녹화 중 닫기 확인 다이얼로그 (window.confirm 대신 in-tree UI) */}
+      {closePending ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="close-dialog-title"
+          className="absolute inset-0 flex items-center justify-center bg-black/70 p-6"
+        >
+          <div className="w-full max-w-xs rounded-2xl bg-white p-6 text-center shadow-xl">
+            <p
+              id="close-dialog-title"
+              className="mb-1 text-base font-semibold text-gray-900"
+            >
+              녹화를 종료할까요?
+            </p>
+            <p className="mb-6 text-sm text-gray-500">
+              현재 녹화가 취소되고 저장되지 않습니다.
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={handleCancelClose}
+                className="flex-1 rounded-xl border border-gray-200 py-2.5 text-sm font-medium text-gray-700"
+              >
+                계속 촬영
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmClose}
+                className="flex-1 rounded-xl bg-red-500 py-2.5 text-sm font-medium text-white"
+              >
+                종료
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/features/film/ui/CameraPane.tsx
+++ b/features/film/ui/CameraPane.tsx
@@ -11,6 +11,8 @@ import { saveToGallery } from "../model/save-to-gallery";
 interface CameraPaneProps {
   stream: MediaStream | null;
   mimeType: string;
+  recording: boolean;
+  onRecordingChange: (recording: boolean) => void;
   onFlip: () => void;
   onClose: () => void;
   onSaveError?: (err: unknown) => void;
@@ -20,13 +22,14 @@ interface CameraPaneProps {
 export function CameraPane({
   stream,
   mimeType,
+  recording,
+  onRecordingChange,
   onFlip,
   onClose,
   onSaveError,
   children,
 }: CameraPaneProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const [recording, setRecording] = useState(false);
   const [closePending, setClosePending] = useState(false);
   // handleRef: recording 중 ref로 관리해 상태와 분리 — race condition 방지
   const handleRef = useRef<RecordingHandle | null>(null);
@@ -72,13 +75,13 @@ export function CameraPane({
       if (!handleRef.current) {
         if (!stream) return;
         handleRef.current = startRecording(stream, mimeType);
-        setRecording(true);
+        onRecordingChange(true);
         return;
       }
 
       const handle = handleRef.current;
       handleRef.current = null;
-      setRecording(false);
+      onRecordingChange(false);
       try {
         const blob = await handle.stop();
         await saveToGallery(blob, extensionFor(mimeType));
@@ -102,7 +105,7 @@ export function CameraPane({
     setClosePending(false);
     const handle = handleRef.current;
     handleRef.current = null;
-    setRecording(false);
+    onRecordingChange(false);
     // stop()을 await해 MediaRecorder가 flush할 시간을 준 뒤 닫기
     if (handle) await handle.stop().catch(() => {});
     onClose();
@@ -148,8 +151,8 @@ export function CameraPane({
       {/* ProgramOverlay 슬롯 */}
       {children}
 
-      {/* REC 버튼 */}
-      <div className="absolute bottom-8 left-1/2 flex -translate-x-1/2 flex-col items-center gap-2">
+      {/* REC 버튼 — 하단 ProgramOverlay 띠와 겹치지 않도록 위로 띄움 */}
+      <div className="absolute bottom-24 left-1/2 flex -translate-x-1/2 flex-col items-center gap-2">
         {recording ? (
           <span className="text-xs font-bold tracking-widest text-red-500">
             ● REC

--- a/features/film/ui/FilmView.tsx
+++ b/features/film/ui/FilmView.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Video } from "lucide-react";
+
+import type { ExercisePosition } from "@/features/program-runner/model/types";
+import type { FacingMode } from "../model/use-camera";
+import { startStream, stopStream } from "../model/use-camera";
+import { pickVideoMimeType } from "../model/codecs";
+import {
+  initialState,
+  canPrev,
+  canNext,
+  stepPrev,
+  stepNext,
+} from "../model/film-navigator";
+import type { FilmNavigatorState } from "../model/film-navigator";
+import { CameraPane } from "./CameraPane";
+import { ProgramOverlay } from "./ProgramOverlay";
+
+interface FilmViewProps {
+  positions: ExercisePosition[];
+  initialPositionIdx?: number;
+}
+
+export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
+  const [filmMode, setFilmMode] = useState(false);
+  const [nav, setNav] = useState<FilmNavigatorState>(() =>
+    initialState(initialPositionIdx)
+  );
+  const [stream, setStream] = useState<MediaStream | null>(null);
+  const [mimeType] = useState(() => pickVideoMimeType());
+  const [facing, setFacing] = useState<FacingMode>("environment");
+  const [cameraError, setCameraError] = useState<string | null>(null);
+
+  // 언마운트 cleanup에서 최신 stream에 접근하기 위한 ref
+  const streamRef = useRef<MediaStream | null>(null);
+  streamRef.current = stream;
+
+  const openCamera = useCallback(async () => {
+    setCameraError(null);
+    try {
+      const s = await startStream(facing);
+      setStream(s);
+      setFilmMode(true);
+    } catch {
+      setCameraError("카메라 권한이 필요합니다. 설정에서 카메라 접근을 허용해 주세요.");
+    }
+  }, [facing]);
+
+  const closeCamera = useCallback(() => {
+    if (stream) stopStream(stream);
+    setStream(null);
+    setFilmMode(false);
+  }, [stream]);
+
+  const handleFlip = useCallback(async () => {
+    const nextFacing: FacingMode = facing === "environment" ? "user" : "environment";
+    if (stream) stopStream(stream);
+    setFacing(nextFacing);
+    try {
+      const s = await startStream(nextFacing);
+      setStream(s);
+    } catch {
+      setStream(null);
+      setFilmMode(false);
+      setCameraError("카메라를 전환할 수 없습니다.");
+    }
+  }, [facing, stream]);
+
+  // 언마운트 시 스트림 정리 — setState 없이 ref를 통해 직접 해제
+  useEffect(() => {
+    return () => {
+      if (streamRef.current) stopStream(streamRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const currentPosition = positions[nav.positionIdx];
+
+  if (filmMode && currentPosition) {
+    return (
+      <div className="fixed inset-0 z-50 bg-black">
+        <CameraPane
+          stream={stream}
+          mimeType={mimeType}
+          onFlip={handleFlip}
+          onClose={closeCamera}
+          onSaveError={(err) =>
+            setCameraError(
+              err instanceof Error ? err.message : "영상 저장에 실패했습니다."
+            )
+          }
+        >
+          <ProgramOverlay
+            position={currentPosition}
+            setIdx={nav.setIdx}
+            canPrev={canPrev(nav)}
+            canNext={canNext(nav, positions)}
+            onPrev={() => setNav((s) => stepPrev(s, positions))}
+            onNext={() => setNav((s) => stepNext(s, positions))}
+          />
+        </CameraPane>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {cameraError ? (
+        <p
+          role="alert"
+          className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-600"
+        >
+          {cameraError}
+        </p>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        {positions.map((pos, posIdx) => (
+          <div
+            key={`${pos.blockIdx}-${pos.exerciseIdx}`}
+            className={[
+              "rounded-xl border px-4 py-3 text-sm",
+              posIdx === nav.positionIdx
+                ? "border-blue-400 bg-blue-50 font-semibold text-blue-900"
+                : "border-gray-200 bg-white text-gray-700",
+            ].join(" ")}
+          >
+            <span className="block font-medium">{pos.movement.name}</span>
+            <span className="text-xs text-gray-500">
+              {pos.sets.length}세트
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={openCamera}
+        className="mt-2 flex w-full items-center justify-center gap-2 rounded-2xl bg-gray-900 py-4 text-base font-semibold text-white active:scale-95"
+      >
+        <Video className="h-5 w-5" />
+        촬영하기
+      </button>
+    </div>
+  );
+}

--- a/features/film/ui/FilmView.tsx
+++ b/features/film/ui/FilmView.tsx
@@ -65,6 +65,15 @@ export function FilmView({
   streamRef.current = stream;
   // handleFlip 진행 중 이중 호출 방지
   const flippingRef = useRef(false);
+  // 비동기 startStream 완료 시점에 마운트 여부 확인 — 언마운트 후 생성된 스트림 누수 방지
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   // 마운트 시 카메라를 즉시 연다 — 중간 단계 없이 1탭 진입
   useEffect(() => {
@@ -106,12 +115,20 @@ export function FilmView({
     setFacing(nextFacing);
     try {
       const s = await startStream(nextFacing);
+      if (!mountedRef.current) {
+        stopStream(s);
+        return;
+      }
       setStream(s);
     } catch {
       // 전환 실패 — 촬영을 유지하기 위해 이전 카메라로 복구 시도
       setFacing(prevFacing);
       try {
         const s = await startStream(prevFacing);
+        if (!mountedRef.current) {
+          stopStream(s);
+          return;
+        }
         setStream(s);
       } catch {
         setStream(null);

--- a/features/film/ui/FilmView.tsx
+++ b/features/film/ui/FilmView.tsx
@@ -36,6 +36,8 @@ export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
   // 언마운트 cleanup에서 최신 stream에 접근하기 위한 ref
   const streamRef = useRef<MediaStream | null>(null);
   streamRef.current = stream;
+  // handleFlip 진행 중 이중 호출 방지
+  const flippingRef = useRef(false);
 
   const openCamera = useCallback(async () => {
     setCameraError(null);
@@ -43,8 +45,17 @@ export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
       const s = await startStream(facing);
       setStream(s);
       setFilmMode(true);
-    } catch {
-      setCameraError("카메라 권한이 필요합니다. 설정에서 카메라 접근을 허용해 주세요.");
+    } catch (err) {
+      const name = err instanceof DOMException ? err.name : "";
+      if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+        setCameraError("카메라를 찾을 수 없습니다. 디바이스에 카메라가 연결되어 있는지 확인해 주세요.");
+      } else if (name === "OverconstrainedError" || name === "ConstraintNotSatisfiedError") {
+        setCameraError("카메라 설정을 지원하지 않습니다. 다른 카메라를 시도해 주세요.");
+      } else if (name === "NotReadableError" || name === "TrackStartError") {
+        setCameraError("카메라를 사용할 수 없습니다. 다른 앱에서 카메라를 사용 중인지 확인해 주세요.");
+      } else {
+        setCameraError("카메라 권한이 필요합니다. 설정에서 카메라 접근을 허용해 주세요.");
+      }
     }
   }, [facing]);
 
@@ -55,6 +66,10 @@ export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
   }, [stream]);
 
   const handleFlip = useCallback(async () => {
+    if (flippingRef.current) return;
+    flippingRef.current = true;
+
+    const prevFacing = facing;
     const nextFacing: FacingMode = facing === "environment" ? "user" : "environment";
     if (stream) stopStream(stream);
     setFacing(nextFacing);
@@ -64,7 +79,10 @@ export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
     } catch {
       setStream(null);
       setFilmMode(false);
+      setFacing(prevFacing);
       setCameraError("카메라를 전환할 수 없습니다.");
+    } finally {
+      flippingRef.current = false;
     }
   }, [facing, stream]);
 
@@ -119,7 +137,7 @@ export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
       <div className="flex flex-col gap-2">
         {positions.map((pos, posIdx) => (
           <div
-            key={`${pos.blockIdx}-${pos.exerciseIdx}`}
+            key={posIdx}
             className={[
               "rounded-xl border px-4 py-3 text-sm",
               posIdx === nav.positionIdx

--- a/features/film/ui/FilmView.tsx
+++ b/features/film/ui/FilmView.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Video } from "lucide-react";
 
-import type { ExercisePosition } from "@/features/program-runner/model/types";
+import type {
+  ExercisePosition,
+  SetRecord,
+} from "@/features/program-runner/model/types";
 import type { FacingMode } from "../model/use-camera";
 import { startStream, stopStream } from "../model/use-camera";
 import { pickVideoMimeType } from "../model/codecs";
@@ -19,13 +21,40 @@ import { ProgramOverlay } from "./ProgramOverlay";
 
 interface FilmViewProps {
   positions: ExercisePosition[];
-  posIdx: number;
-  setIdx: number;
-  onNavigate: (posIdx: number, setIdx: number) => void;
+  records: SetRecord[][];
+  /** 카메라를 열 때 시작할 위치 — 이후 탐색은 로컬 상태로 운동 로깅과 분리된다 */
+  initialPosIdx: number;
+  initialSetIdx: number;
+  onClose: () => void;
 }
 
-export function FilmView({ positions, posIdx, setIdx, onNavigate }: FilmViewProps) {
-  const [filmMode, setFilmMode] = useState(false);
+function cameraErrorMessage(err: unknown): string {
+  const name = err instanceof DOMException ? err.name : "";
+  if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+    return "카메라를 찾을 수 없습니다. 디바이스에 카메라가 연결되어 있는지 확인해 주세요.";
+  }
+  if (name === "OverconstrainedError" || name === "ConstraintNotSatisfiedError") {
+    return "카메라 설정을 지원하지 않습니다. 다른 카메라를 시도해 주세요.";
+  }
+  if (name === "NotReadableError" || name === "TrackStartError") {
+    return "카메라를 사용할 수 없습니다. 다른 앱에서 카메라를 사용 중인지 확인해 주세요.";
+  }
+  return "카메라 권한이 필요합니다. 설정에서 카메라 접근을 허용해 주세요.";
+}
+
+export function FilmView({
+  positions,
+  records,
+  initialPosIdx,
+  initialSetIdx,
+  onClose,
+}: FilmViewProps) {
+  // 촬영 탐색은 로컬 상태 — 운동 로깅(Standard/Focus의 현재 세트)과 분리된다
+  const [nav, setNav] = useState<FilmNavigatorState>({
+    positionIdx: initialPosIdx,
+    setIdx: initialSetIdx,
+  });
+  const [recording, setRecording] = useState(false);
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [mimeType] = useState(() => pickVideoMimeType());
   const [facing, setFacing] = useState<FacingMode>("environment");
@@ -37,135 +66,109 @@ export function FilmView({ positions, posIdx, setIdx, onNavigate }: FilmViewProp
   // handleFlip 진행 중 이중 호출 방지
   const flippingRef = useRef(false);
 
-  const openCamera = useCallback(async () => {
-    setCameraError(null);
-    try {
-      const s = await startStream(facing);
-      setStream(s);
-      setFilmMode(true);
-    } catch (err) {
-      const name = err instanceof DOMException ? err.name : "";
-      if (name === "NotFoundError" || name === "DevicesNotFoundError") {
-        setCameraError("카메라를 찾을 수 없습니다. 디바이스에 카메라가 연결되어 있는지 확인해 주세요.");
-      } else if (name === "OverconstrainedError" || name === "ConstraintNotSatisfiedError") {
-        setCameraError("카메라 설정을 지원하지 않습니다. 다른 카메라를 시도해 주세요.");
-      } else if (name === "NotReadableError" || name === "TrackStartError") {
-        setCameraError("카메라를 사용할 수 없습니다. 다른 앱에서 카메라를 사용 중인지 확인해 주세요.");
-      } else {
-        setCameraError("카메라 권한이 필요합니다. 설정에서 카메라 접근을 허용해 주세요.");
+  // 마운트 시 카메라를 즉시 연다 — 중간 단계 없이 1탭 진입
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const s = await startStream("environment");
+        if (cancelled) {
+          stopStream(s);
+          return;
+        }
+        setStream(s);
+      } catch (err) {
+        if (!cancelled) setCameraError(cameraErrorMessage(err));
       }
-    }
-  }, [facing]);
+    })();
+    return () => {
+      cancelled = true;
+      if (streamRef.current) stopStream(streamRef.current);
+    };
+  }, []);
 
-  const closeCamera = useCallback(() => {
-    if (stream) stopStream(stream);
-    setStream(null);
-    setFilmMode(false);
-  }, [stream]);
+  // 에러 화면으로 전환되면 카메라를 즉시 해제 — 프리뷰가 사라진 채 카메라가 켜져 있지 않도록
+  useEffect(() => {
+    if (cameraError && streamRef.current) {
+      stopStream(streamRef.current);
+      setStream(null);
+    }
+  }, [cameraError]);
 
   const handleFlip = useCallback(async () => {
     if (flippingRef.current) return;
     flippingRef.current = true;
 
     const prevFacing = facing;
-    const nextFacing: FacingMode = facing === "environment" ? "user" : "environment";
+    const nextFacing: FacingMode =
+      facing === "environment" ? "user" : "environment";
     if (stream) stopStream(stream);
     setFacing(nextFacing);
     try {
       const s = await startStream(nextFacing);
       setStream(s);
     } catch {
-      setStream(null);
-      setFilmMode(false);
+      // 전환 실패 — 촬영을 유지하기 위해 이전 카메라로 복구 시도
       setFacing(prevFacing);
-      setCameraError("카메라를 전환할 수 없습니다.");
+      try {
+        const s = await startStream(prevFacing);
+        setStream(s);
+      } catch {
+        setStream(null);
+        setCameraError("카메라를 전환할 수 없습니다.");
+      }
     } finally {
       flippingRef.current = false;
     }
   }, [facing, stream]);
 
-  // 언마운트 시 스트림 정리 — setState 없이 ref를 통해 직접 해제
-  useEffect(() => {
-    return () => {
-      if (streamRef.current) stopStream(streamRef.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const currentPosition = positions[nav.positionIdx];
 
-  const nav: FilmNavigatorState = { positionIdx: posIdx, setIdx };
-  const currentPosition = positions[posIdx];
-
-  if (filmMode && currentPosition) {
+  if (cameraError || !currentPosition) {
     return (
-      <div className="fixed inset-0 z-50 bg-black">
-        <CameraPane
-          stream={stream}
-          mimeType={mimeType}
-          onFlip={handleFlip}
-          onClose={closeCamera}
-          onSaveError={(err) =>
-            setCameraError(
-              err instanceof Error ? err.message : "영상 저장에 실패했습니다."
-            )
-          }
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 bg-black p-6 text-center">
+        <p role="alert" className="text-sm text-red-300">
+          {cameraError ?? "촬영할 동작을 찾을 수 없습니다."}
+        </p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-2xl bg-white px-6 py-3 text-sm font-semibold text-gray-900"
         >
-          <ProgramOverlay
-            position={currentPosition}
-            setIdx={setIdx}
-            canPrev={canPrev(nav)}
-            canNext={canNext(nav, positions)}
-            onPrev={() => {
-              const next = stepPrev(nav, positions);
-              onNavigate(next.positionIdx, next.setIdx);
-            }}
-            onNext={() => {
-              const next = stepNext(nav, positions);
-              onNavigate(next.positionIdx, next.setIdx);
-            }}
-          />
-        </CameraPane>
+          닫기
+        </button>
       </div>
     );
   }
 
+  const kg = records[nav.positionIdx]?.[nav.setIdx]?.kg ?? null;
+
   return (
-    <div className="flex flex-col gap-4 p-4">
-      {cameraError ? (
-        <p
-          role="alert"
-          className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-600"
-        >
-          {cameraError}
-        </p>
-      ) : null}
-
-      <div className="flex flex-col gap-2">
-        {positions.map((pos, posItemIdx) => (
-          <div
-            key={posItemIdx}
-            className={[
-              "rounded-xl border px-4 py-3 text-sm",
-              posItemIdx === posIdx
-                ? "border-blue-400 bg-blue-50 font-semibold text-blue-900"
-                : "border-gray-200 bg-white text-gray-700",
-            ].join(" ")}
-          >
-            <span className="block font-medium">{pos.movement.name}</span>
-            <span className="text-xs text-gray-500">
-              {pos.sets.length}세트
-            </span>
-          </div>
-        ))}
-      </div>
-
-      <button
-        type="button"
-        onClick={openCamera}
-        className="mt-2 flex w-full items-center justify-center gap-2 rounded-2xl bg-gray-900 py-4 text-base font-semibold text-white active:scale-95"
+    <div className="fixed inset-0 z-50 bg-black">
+      <CameraPane
+        stream={stream}
+        mimeType={mimeType}
+        recording={recording}
+        onRecordingChange={setRecording}
+        onFlip={handleFlip}
+        onClose={onClose}
+        onSaveError={(err) =>
+          setCameraError(
+            err instanceof Error ? err.message : "영상 저장에 실패했습니다."
+          )
+        }
       >
-        <Video className="h-5 w-5" />
-        촬영하기
-      </button>
+        <ProgramOverlay
+          position={currentPosition}
+          setIdx={nav.setIdx}
+          kg={kg}
+          canPrev={canPrev(nav)}
+          canNext={canNext(nav, positions)}
+          locked={recording}
+          onPrev={() => setNav((s) => stepPrev(s, positions))}
+          onNext={() => setNav((s) => stepNext(s, positions))}
+        />
+      </CameraPane>
     </div>
   );
 }

--- a/features/film/ui/FilmView.tsx
+++ b/features/film/ui/FilmView.tsx
@@ -8,7 +8,6 @@ import type { FacingMode } from "../model/use-camera";
 import { startStream, stopStream } from "../model/use-camera";
 import { pickVideoMimeType } from "../model/codecs";
 import {
-  initialState,
   canPrev,
   canNext,
   stepPrev,
@@ -20,14 +19,13 @@ import { ProgramOverlay } from "./ProgramOverlay";
 
 interface FilmViewProps {
   positions: ExercisePosition[];
-  initialPositionIdx?: number;
+  posIdx: number;
+  setIdx: number;
+  onNavigate: (posIdx: number, setIdx: number) => void;
 }
 
-export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
+export function FilmView({ positions, posIdx, setIdx, onNavigate }: FilmViewProps) {
   const [filmMode, setFilmMode] = useState(false);
-  const [nav, setNav] = useState<FilmNavigatorState>(() =>
-    initialState(initialPositionIdx)
-  );
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [mimeType] = useState(() => pickVideoMimeType());
   const [facing, setFacing] = useState<FacingMode>("environment");
@@ -94,7 +92,8 @@ export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const currentPosition = positions[nav.positionIdx];
+  const nav: FilmNavigatorState = { positionIdx: posIdx, setIdx };
+  const currentPosition = positions[posIdx];
 
   if (filmMode && currentPosition) {
     return (
@@ -112,11 +111,17 @@ export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
         >
           <ProgramOverlay
             position={currentPosition}
-            setIdx={nav.setIdx}
+            setIdx={setIdx}
             canPrev={canPrev(nav)}
             canNext={canNext(nav, positions)}
-            onPrev={() => setNav((s) => stepPrev(s, positions))}
-            onNext={() => setNav((s) => stepNext(s, positions))}
+            onPrev={() => {
+              const next = stepPrev(nav, positions);
+              onNavigate(next.positionIdx, next.setIdx);
+            }}
+            onNext={() => {
+              const next = stepNext(nav, positions);
+              onNavigate(next.positionIdx, next.setIdx);
+            }}
           />
         </CameraPane>
       </div>
@@ -135,12 +140,12 @@ export function FilmView({ positions, initialPositionIdx = 0 }: FilmViewProps) {
       ) : null}
 
       <div className="flex flex-col gap-2">
-        {positions.map((pos, posIdx) => (
+        {positions.map((pos, posItemIdx) => (
           <div
-            key={posIdx}
+            key={posItemIdx}
             className={[
               "rounded-xl border px-4 py-3 text-sm",
-              posIdx === nav.positionIdx
+              posItemIdx === posIdx
                 ? "border-blue-400 bg-blue-50 font-semibold text-blue-900"
                 : "border-gray-200 bg-white text-gray-700",
             ].join(" ")}

--- a/features/film/ui/ProgramOverlay.tsx
+++ b/features/film/ui/ProgramOverlay.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import type { ExercisePosition } from "@/features/program-runner/model/types";
+import { formatOverlayLabel } from "../model/overlay-label";
+
+interface ProgramOverlayProps {
+  position: ExercisePosition;
+  setIdx: number;
+  canPrev: boolean;
+  canNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+const FADE_DELAY_MS = 3000;
+
+export function ProgramOverlay({
+  position,
+  setIdx,
+  canPrev,
+  canNext,
+  onPrev,
+  onNext,
+}: ProgramOverlayProps) {
+  const [visible, setVisible] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // ref로 현재 가시 상태 추적 — handleTap이 visible 상태에 의존하지 않도록
+  const visibleRef = useRef(true);
+
+  const scheduleHide = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      visibleRef.current = false;
+      setVisible(false);
+    }, FADE_DELAY_MS);
+  }, []);
+
+  const handleTap = useCallback(() => {
+    if (!visibleRef.current) {
+      visibleRef.current = true;
+      setVisible(true);
+      scheduleHide();
+    } else {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      visibleRef.current = false;
+      setVisible(false);
+    }
+  }, [scheduleHide]);
+
+  useEffect(() => {
+    scheduleHide();
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [scheduleHide]);
+
+  const set = position.sets[setIdx];
+  const label = set ? formatOverlayLabel(position.movement, set) : "";
+
+  return (
+    <div
+      className={[
+        "absolute inset-x-0 bottom-0 flex items-center gap-3 px-4 py-3",
+        "bg-black/50 backdrop-blur-sm transition-opacity duration-300",
+        visible ? "opacity-100" : "opacity-0 pointer-events-none",
+      ].join(" ")}
+      role="region"
+      aria-label="현재 세트 정보"
+      onClick={handleTap}
+    >
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onPrev();
+        }}
+        disabled={!canPrev}
+        aria-label="이전 세트"
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white disabled:opacity-30"
+      >
+        <ChevronLeft className="h-5 w-5" />
+      </button>
+
+      <span className="flex-1 text-center text-sm font-semibold text-white">
+        {label}
+      </span>
+
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onNext();
+        }}
+        disabled={!canNext}
+        aria-label="다음 세트"
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white disabled:opacity-30"
+      >
+        <ChevronRight className="h-5 w-5" />
+      </button>
+    </div>
+  );
+}

--- a/features/film/ui/ProgramOverlay.tsx
+++ b/features/film/ui/ProgramOverlay.tsx
@@ -34,13 +34,13 @@ export function ProgramOverlay({
     <div
       className="absolute inset-x-0 bottom-0 flex items-center gap-3 bg-black/50 px-4 py-3 backdrop-blur-sm"
       role="region"
-      aria-label="현재 세트 정보"
+      aria-label="Current set info"
     >
       <button
         type="button"
         onClick={onPrev}
         disabled={locked || !canPrev}
-        aria-label="이전 세트"
+        aria-label="Previous set"
         className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white disabled:opacity-30"
       >
         <ChevronLeft className="h-5 w-5" />
@@ -54,7 +54,7 @@ export function ProgramOverlay({
         type="button"
         onClick={onNext}
         disabled={locked || !canNext}
-        aria-label="다음 세트"
+        aria-label="Next set"
         className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white disabled:opacity-30"
       >
         <ChevronRight className="h-5 w-5" />

--- a/features/film/ui/ProgramOverlay.tsx
+++ b/features/film/ui/ProgramOverlay.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import type { ExercisePosition } from "@/features/program-runner/model/types";
@@ -9,75 +8,38 @@ import { formatOverlayLabel } from "../model/overlay-label";
 interface ProgramOverlayProps {
   position: ExercisePosition;
   setIdx: number;
+  kg: number | null;
   canPrev: boolean;
   canNext: boolean;
+  /** 녹화 중에는 세트 이동을 잠근다 */
+  locked: boolean;
   onPrev: () => void;
   onNext: () => void;
 }
 
-const FADE_DELAY_MS = 3000;
-
 export function ProgramOverlay({
   position,
   setIdx,
+  kg,
   canPrev,
   canNext,
+  locked,
   onPrev,
   onNext,
 }: ProgramOverlayProps) {
-  const [visible, setVisible] = useState(true);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // ref로 현재 가시 상태 추적 — handleTap이 visible 상태에 의존하지 않도록
-  const visibleRef = useRef(true);
-
-  const scheduleHide = useCallback(() => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      visibleRef.current = false;
-      setVisible(false);
-    }, FADE_DELAY_MS);
-  }, []);
-
-  const handleTap = useCallback(() => {
-    if (!visibleRef.current) {
-      visibleRef.current = true;
-      setVisible(true);
-      scheduleHide();
-    } else {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      visibleRef.current = false;
-      setVisible(false);
-    }
-  }, [scheduleHide]);
-
-  useEffect(() => {
-    scheduleHide();
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [scheduleHide]);
-
   const set = position.sets[setIdx];
-  const label = set ? formatOverlayLabel(position.movement, set) : "";
+  const label = set ? formatOverlayLabel(position.movement, set, kg) : "";
 
   return (
     <div
-      className={[
-        "absolute inset-x-0 bottom-0 flex items-center gap-3 px-4 py-3",
-        "bg-black/50 backdrop-blur-sm transition-opacity duration-300",
-        visible ? "opacity-100" : "opacity-0 pointer-events-none",
-      ].join(" ")}
+      className="absolute inset-x-0 bottom-0 flex items-center gap-3 bg-black/50 px-4 py-3 backdrop-blur-sm"
       role="region"
       aria-label="현재 세트 정보"
-      onClick={handleTap}
     >
       <button
         type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onPrev();
-        }}
-        disabled={!canPrev}
+        onClick={onPrev}
+        disabled={locked || !canPrev}
         aria-label="이전 세트"
         className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white disabled:opacity-30"
       >
@@ -90,11 +52,8 @@ export function ProgramOverlay({
 
       <button
         type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onNext();
-        }}
-        disabled={!canNext}
+        onClick={onNext}
+        disabled={locked || !canNext}
         aria-label="다음 세트"
         className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white disabled:opacity-30"
       >

--- a/features/program-runner/ui/ProgramRunner.tsx
+++ b/features/program-runner/ui/ProgramRunner.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { ROUTES } from "@/routes";
 import type { Program } from "@/features/notation/model/types";
 import { useBarbellWeight } from "@/hooks/useBarbellWeight";
+import { FilmView } from "@/features/film/ui/FilmView";
 
 import { flattenProgram } from "../model/flatten";
 import { propagateManualWeight } from "../model/propagate-weight";
@@ -22,7 +23,7 @@ interface ProgramRunnerProps {
   prMap: Readonly<Record<number, number>>;
 }
 
-type ViewMode = "standard" | "focus";
+type ViewMode = "standard" | "focus" | "film";
 
 /** Build initial record state: records[posIdx][setIdx] = { kg, done } */
 function buildInitialRecords(
@@ -130,7 +131,7 @@ export function ProgramRunner({ program, aliasMap, prRefMap, prMap }: ProgramRun
 
       <ViewToggle view={view} onChange={setView} />
 
-      {view === "standard" ? (
+      {view === "standard" && (
         <RunnerStandardView
           position={position}
           records={currentRecords}
@@ -144,7 +145,8 @@ export function ProgramRunner({ program, aliasMap, prRefMap, prMap }: ProgramRun
           onSelectSet={setSetIdx}
           onSetKg={handleSetKg}
         />
-      ) : (
+      )}
+      {view === "focus" && (
         <RunnerFocusView
           position={position}
           records={currentRecords}
@@ -155,6 +157,17 @@ export function ProgramRunner({ program, aliasMap, prRefMap, prMap }: ProgramRun
           onPrev={handlePrev}
           onNext={handleNext}
           onLogSet={handleLogSet}
+        />
+      )}
+      {view === "film" && (
+        <FilmView
+          positions={positions}
+          posIdx={posIdx}
+          setIdx={setIdx}
+          onNavigate={(nextPos, nextSet) => {
+            setPosIdx(nextPos);
+            setSetIdx(nextSet);
+          }}
         />
       )}
     </div>
@@ -170,6 +183,7 @@ function ViewToggle({ view, onChange }: ViewToggleProps) {
   const options: Array<{ id: ViewMode; label: string }> = [
     { id: "standard", label: "Standard" },
     { id: "focus", label: "Focus" },
+    { id: "film", label: "촬영" },
   ];
   return (
     <div

--- a/features/program-runner/ui/ProgramRunner.tsx
+++ b/features/program-runner/ui/ProgramRunner.tsx
@@ -23,7 +23,7 @@ interface ProgramRunnerProps {
   prMap: Readonly<Record<number, number>>;
 }
 
-type ViewMode = "standard" | "focus" | "film";
+type ViewMode = "standard" | "focus";
 
 /** Build initial record state: records[posIdx][setIdx] = { kg, done } */
 function buildInitialRecords(
@@ -55,6 +55,7 @@ export function ProgramRunner({ program, aliasMap, prRefMap, prMap }: ProgramRun
   const [posIdx, setPosIdx] = useState(0);
   const [setIdx, setSetIdx] = useState(0);
   const [view, setView] = useState<ViewMode>("standard");
+  const [filming, setFilming] = useState(false);
 
   if (positions.length === 0) {
     return (
@@ -127,6 +128,7 @@ export function ProgramRunner({ program, aliasMap, prRefMap, prMap }: ProgramRun
         exerciseIdx={position.exerciseIdx}
         totalExercises={position.totalExercises}
         onClose={() => router.push(ROUTES.HOME)}
+        onFilm={() => setFilming(true)}
       />
 
       <ViewToggle view={view} onChange={setView} />
@@ -159,15 +161,13 @@ export function ProgramRunner({ program, aliasMap, prRefMap, prMap }: ProgramRun
           onLogSet={handleLogSet}
         />
       )}
-      {view === "film" && (
+      {filming && (
         <FilmView
           positions={positions}
-          posIdx={posIdx}
-          setIdx={setIdx}
-          onNavigate={(nextPos, nextSet) => {
-            setPosIdx(nextPos);
-            setSetIdx(nextSet);
-          }}
+          records={records}
+          initialPosIdx={posIdx}
+          initialSetIdx={setIdx}
+          onClose={() => setFilming(false)}
         />
       )}
     </div>
@@ -183,7 +183,6 @@ function ViewToggle({ view, onChange }: ViewToggleProps) {
   const options: Array<{ id: ViewMode; label: string }> = [
     { id: "standard", label: "Standard" },
     { id: "focus", label: "Focus" },
-    { id: "film", label: "촬영" },
   ];
   return (
     <div

--- a/features/program-runner/ui/RunnerHeader.tsx
+++ b/features/program-runner/ui/RunnerHeader.tsx
@@ -67,7 +67,7 @@ export function RunnerHeader({
         <button
           type="button"
           onClick={onFilm}
-          aria-label="촬영"
+          aria-label="Film"
           className="flex h-8 w-8 items-center justify-center text-yd-text-muted"
         >
           <Video className="h-5 w-5" />

--- a/features/program-runner/ui/RunnerHeader.tsx
+++ b/features/program-runner/ui/RunnerHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { X } from "lucide-react";
+import { Video, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { ROUTES } from "@/routes";
@@ -12,6 +12,7 @@ interface RunnerHeaderProps {
   exerciseIdx: number;
   totalExercises: number;
   onClose?: () => void;
+  onFilm?: () => void;
 }
 
 export function RunnerHeader({
@@ -20,6 +21,7 @@ export function RunnerHeader({
   exerciseIdx,
   totalExercises,
   onClose,
+  onFilm,
 }: RunnerHeaderProps) {
   const currentEx = exerciseIdx + 1;
 
@@ -61,8 +63,18 @@ export function RunnerHeader({
         </div>
       </div>
 
-      {/* Right slot kept visible as a reserved affordance (PR shortcut) */}
-      <span className="w-8" aria-hidden />
+      {onFilm ? (
+        <button
+          type="button"
+          onClick={onFilm}
+          aria-label="촬영"
+          className="flex h-8 w-8 items-center justify-center text-yd-text-muted"
+        >
+          <Video className="h-5 w-5" />
+        </button>
+      ) : (
+        <span className="w-8" aria-hidden />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 개요

프로그램 진행 중 **운동 폼을 영상으로 촬영**하는 Training Film Mode를 추가합니다. 카메라 프리뷰 위에 현재 동작·무게 정보를 오버레이로 띄우고, 녹화한 영상을 갤러리에 저장합니다.

## 주요 기능

- **헤더 카메라 아이콘 1탭 진입** — 러너 어느 뷰에서든 현재 세트 기준으로 풀스크린 카메라 즉시 진입 (뷰 토글은 Standard/Focus 표시 밀도 전용으로 정리)
- **풀스크린 카메라 + REC UI** (`CameraPane`) — 전/후면 전환, 녹화/정지, 녹화 중 닫기 확인
- **하단 프로그램 띠 상시 표시** (`ProgramOverlay`) — `동작 · 무게(kg) · % · Set n/m` 라벨, ◀▶로 세트 이동
- **촬영 탐색 = 운동 로깅과 분리** — 카메라 안 ◀▶는 로컬 상태로 동작, Standard/Focus의 현재 세트를 건드리지 않음
- **녹화 중 ◀▶ 잠금** — 녹화 전엔 세트 이동, 녹화 시작하면 고정
- **영상 저장** (`saveToGallery`) — Web Share API + 다운로드 폴백
- **MediaRecorder 코덱 자동 선택** (`codecs`)

## 설계 메모

- `features/film/` 피처로 분리, model(순수 로직)/ui(컴포넌트) 3-tier 구조
- 네비게이션 로직은 `film-navigator` 모델로 추출 — 세트/포지션 경계 클램프
- flip 실패 시 이전 카메라로 복구해 촬영 끊김 방지
- 에러 화면 전환 시 카메라 스트림 즉시 해제 (리소스 누수 방지)

## 테스트

- ✅ model 단위 테스트 44개 통과 (codecs / film-navigator / overlay-label / save-to-gallery / use-camera)
- ✅ tsc / eslint 통과
- ✅ `/code-review` 2회(통합분 + UX 개편분) 수행, 지적사항 반영

### 수동 검증 TODO (실기기 — HTTPS 필요)

- [ ] 헤더 카메라 아이콘 1탭 → 현재 세트 카메라 진입
- [ ] 전/후면 전환, 단일 카메라 기기에서 복구 동작
- [ ] 녹화 → 정지 → 갤러리 저장(Web Share/다운로드)
- [ ] 하단 띠 상시 표시 + ◀▶ 세트 이동(녹화 중 잠금)
- [ ] 권한 거부 / 카메라 점유 시 에러 메시지
- [ ] 닫기 시 카메라 스트림 해제(LED off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로그램 실행 중 영상 촬영 모드 추가(카메라 프리뷰, 녹화 토글, 플립, 종료 확인)
  * 촬영된 영상 자동 저장/공유(공유 실패 시 다운로드 폴백)
  * 화면 오버레이로 현재 운동·무게·세트 정보 표시 및 이전/다음 탐색

* **Tests**
  * 카메라 스트림·녹화·저장 흐름, 오버레이 라벨, 내비게이션 로직 등 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->